### PR TITLE
Pull request for plugin_redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,43 @@ See the [Ansible Community Guide](https://docs.ansible.com/ansible/latest/commun
 GNU General Public License v3.0 or later.
 
 See [LICENSE](https://www.gnu.org/licenses/gpl-3.0.txt) to see the full text.
+
+<!--start collection content-->
+## Modules
+Name | Description
+--- | ---
+[junipernetworks.junos.junos_acl_interfaces](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_acl_interfaces.rst)|ACL interfaces resource module
+[junipernetworks.junos.junos_acls](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_acls.rst)|ACLs resource module
+[junipernetworks.junos.junos_banner](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_banner.rst)|Manage multiline banners on Juniper JUNOS devices
+[junipernetworks.junos.junos_command](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_command.rst)|Run arbitrary commands on an Juniper JUNOS device
+[junipernetworks.junos.junos_config](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_config.rst)|Manage configuration on devices running Juniper JUNOS
+[junipernetworks.junos.junos_facts](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_facts.rst)|Collect facts from remote devices running Juniper Junos
+[junipernetworks.junos.junos_interface](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_interface.rst)|(deprecated) Manage Interface on Juniper JUNOS network devices
+[junipernetworks.junos.junos_interfaces](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_interfaces.rst)|Manages interface attributes of Juniper Junos OS network devices.
+[junipernetworks.junos.junos_l2_interface](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_l2_interface.rst)|(deprecated) Manage Layer-2 interface on Juniper JUNOS network devices
+[junipernetworks.junos.junos_l2_interfaces](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_l2_interfaces.rst)|L2 interfaces resource module
+[junipernetworks.junos.junos_l3_interface](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_l3_interface.rst)|(deprecated) Manage L3 interfaces on Juniper JUNOS network devices
+[junipernetworks.junos.junos_l3_interfaces](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_l3_interfaces.rst)|L3 interfaces resource module
+[junipernetworks.junos.junos_lacp](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_lacp.rst)|Manage Global Link Aggregation Control Protocol (LACP) on Juniper Junos devices
+[junipernetworks.junos.junos_lacp_interfaces](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_lacp_interfaces.rst)|LACP interfaces resource module
+[junipernetworks.junos.junos_lag_interfaces](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_lag_interfaces.rst)|Manage Link Aggregation on Juniper JUNOS devices.
+[junipernetworks.junos.junos_linkagg](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_linkagg.rst)|(deprecated) Manage link aggregation groups on Juniper JUNOS network devices
+[junipernetworks.junos.junos_lldp](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_lldp.rst)|(deprecated) Manage LLDP configuration on Juniper JUNOS network devices
+[junipernetworks.junos.junos_lldp_global](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_lldp_global.rst)|LLDP resource module
+[junipernetworks.junos.junos_lldp_interface](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_lldp_interface.rst)|(deprecated) Manage LLDP interfaces configuration on Juniper JUNOS network devices
+[junipernetworks.junos.junos_lldp_interfaces](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_lldp_interfaces.rst)|LLDP interfaces resource module
+[junipernetworks.junos.junos_logging](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_logging.rst)|Manage logging on network devices
+[junipernetworks.junos.junos_netconf](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_netconf.rst)|Configures the Junos Netconf system service
+[junipernetworks.junos.junos_ospf](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_ospf.rst)|OSPF resource module
+[junipernetworks.junos.junos_package](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_package.rst)|Installs packages on remote devices running Junos
+[junipernetworks.junos.junos_ping](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_ping.rst)|Tests reachability using ping from devices running Juniper JUNOS
+[junipernetworks.junos.junos_rpc](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_rpc.rst)|Runs an arbitrary RPC over NetConf on an Juniper JUNOS device
+[junipernetworks.junos.junos_scp](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_scp.rst)|Transfer files from or to remote devices running Junos
+[junipernetworks.junos.junos_static_route](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_static_route.rst)|(deprecated) Manage static IP routes on Juniper JUNOS network devices
+[junipernetworks.junos.junos_static_routes](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_static_routes.rst)|Static routes resource module
+[junipernetworks.junos.junos_system](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_system.rst)|Manage the system attributes on Juniper JUNOS devices
+[junipernetworks.junos.junos_user](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_user.rst)|Manage local user accounts on Juniper JUNOS devices
+[junipernetworks.junos.junos_vlan](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_vlan.rst)|(deprecated) Manage VLANs on Juniper JUNOS network devices
+[junipernetworks.junos.junos_vlans](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_vlans.rst)|VLANs resource module
+[junipernetworks.junos.junos_vrf](https://github.com/ansible-collections/junipernetworks.junos/blob/master/docs/junipernetworks.junos.junos_vrf.rst)|Manage the VRF definitions on Juniper JUNOS devices
+<!--end collection content-->

--- a/docs/junipernetworks.junos.junos_acl_interfaces.rst
+++ b/docs/junipernetworks.junos.junos_acl_interfaces.rst
@@ -1,0 +1,516 @@
+
+.. _junipernetworks.junos.junos_acl_interfaces_:
+
+
+*****
+junipernetworks.junos.junos_acl_interfaces
+*****
+
+**ACL interfaces resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module manages adding and removing Access Control Lists (ACLs) from interfaces on devices running Juniper JUNOS.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+- xmltodict (>=0.12.0)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="4">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A dictionary of ACL options for interfaces.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>access_groups</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies ACLs attached to the interface.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>acls</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the ACLs for the provided AFI.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>direction</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>in</li>
+                                                                                                                                                                                                <li>out</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the direction of packets that the ACL will be applied on.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the name of the IPv4/IPv4 ACL for the interface.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>afi</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>ipv4</li>
+                                                                                                                                                                                                <li>ipv6</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the AFI for the ACL(s) to be configured on this interface.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name/Identifier for the interface.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                                                                                                                                <li>gathered</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state the configuration should be left in.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the device being managed.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - Tested against JunOS v18.4R1
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using deleted
+
+    # Before state:
+    # -------------
+    #
+    # admin# show interfaces
+    # ge-1/0/0 {
+    #     description "L3 interface with filter";
+    #     unit 0 {
+    #         family inet {
+    #             filter {
+    #                 input inbound_acl;
+    #                 output outbound_acl;
+    #             }
+    #             address 100.64.0.1/10;
+    #             address 100.64.0.2/10;
+    #         }
+    #         family inet6;
+    #     }
+
+    - name: Delete JUNOS L3 interface filter
+      junipernetworks.junos.junos_acl_interfaces:
+        config:
+        - name: ge-1/0/0
+          access_groups:
+          - afi: ipv4
+            acls:
+            - name: inbound_acl
+              direction: in
+            - name: outbound_acl
+              direction: out
+          state: deleted
+
+    # After state:
+    # -------------
+    #
+    # admin# show interfaces
+    # ge-1/0/0 {
+    #     description "L3 interface with filter";
+    #     unit 0 {
+    #         family inet {
+    #             address 100.64.0.1/10;
+    #             address 100.64.0.2/10;
+    #         }
+    #         family inet6;
+    #     }
+
+
+    # Using merged
+
+    # Before state:
+    # -------------
+    #
+    # admin# show interfaces
+    # ge-1/0/0 {
+    #     description "L3 interface without filter";
+    #     unit 0 {
+    #         family inet {
+    #             address 100.64.0.1/10;
+    #             address 100.64.0.2/10;
+    #         }
+    #         family inet6;
+    #     }
+
+    - name: Merge JUNOS L3 interface filter
+      junipernetworks.junos.junos_acl_interfaces:
+        config:
+        - name: ge-1/0/0
+          access_groups:
+          - afi: ipv4
+            acls:
+            - name: inbound_acl
+              direction: in
+            - name: outbound_acl
+              direction: out
+          state: merged
+
+    # After state:
+    # -------------
+    #
+    # admin# show interfaces
+    # ge-1/0/0 {
+    #     description "L3 interface with filter";
+    #     unit 0 {
+    #         family inet {
+    #             filter {
+    #                 input inbound_acl;
+    #                 output outbound_acl;
+    #             }
+    #             address 100.64.0.1/10;
+    #             address 100.64.0.2/10;
+    #         }
+    #         family inet6;
+    #     }
+
+
+    # Using overridden
+
+    # Before state:
+    # -------------
+    #
+    # admin# show interfaces
+    # ge-1/0/0 {
+    #     description "L3 interface without filter";
+    #     unit 0 {
+    #         family inet {
+    #             filter {
+    #                 input foo_acl;
+    #             }
+    #             address 100.64.0.1/10;
+    #             address 100.64.0.2/10;
+    #         }
+    #         family inet6;
+    #     }
+
+    - name: Override JUNOS L3 interface filter
+      junipernetworks.junos.junos_acl_interfaces:
+        config:
+        - name: ge-1/0/0
+          access_groups:
+          - afi: ipv4
+            acls:
+            - name: inbound_acl
+              direction: in
+            - name: outbound_acl
+              direction: out
+          state: overridden
+
+    # After state:
+    # -------------
+    #
+    # admin# show interfaces
+    # ge-1/0/0 {
+    #     description "L3 interface with filter";
+    #     unit 0 {
+    #         family inet {
+    #             filter {
+    #                 input inbound_acl;
+    #                 output outbound_acl;
+    #             }
+    #             address 100.64.0.1/10;
+    #             address 100.64.0.2/10;
+    #         }
+    #         family inet6;
+    #     }
+
+
+    # Using replaced
+
+    # Before state:
+    # -------------
+    #
+    # admin# show interfaces
+    # ge-1/0/0 {
+    #     description "L3 interface without filter";
+    #     unit 0 {
+    #         family inet {
+    #             filter {
+    #                 input foo_acl;
+    #                 output outbound_acl;
+    #             }
+    #             address 100.64.0.1/10;
+    #             address 100.64.0.2/10;
+    #         }
+    #         family inet6;
+    #     }
+
+    - name: Replace JUNOS L3 interface filter
+      junipernetworks.junos.junos_acl_interfaces:
+        config:
+        - name: ge-1/0/0
+          access_groups:
+          - afi: ipv4
+            acls:
+            - name: inbound_acl
+              direction: in
+          state: replaced
+
+    # After state:
+    # -------------
+    #
+    # admin# show interfaces
+    # ge-1/0/0 {
+    #     description "L3 interface with filter";
+    #     unit 0 {
+    #         family inet {
+    #             filter {
+    #                 input inbound_acl;
+    #                 output outbound_acl;
+    #             }
+    #             address 100.64.0.1/10;
+    #             address 100.64.0.2/10;
+    #         }
+    #         family inet6;
+    #     }
+
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">-</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The resulting configuration model invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">-</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration prior to the model invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;command 1&#x27;, &#x27;command 2&#x27;, &#x27;command 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Daniel Mellado (@dmellado)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_acls.rst
+++ b/docs/junipernetworks.junos.junos_acls.rst
@@ -1,0 +1,1316 @@
+
+.. _junipernetworks.junos.junos_acls_:
+
+
+*****
+junipernetworks.junos.junos_acls
+*****
+
+**ACLs resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides declarative management of acls/filters on Juniper JUNOS devices
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+- xmltodict (>=0.12.0)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="7">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="7">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A dictionary of acls options</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="6">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>acls</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of Access Control Lists (ACLs).</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="5">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aces</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of Access Control Entries (ACEs) for this Access Control List (ACL).</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>destination</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the destination for the filter</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>address</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Match IP destination address</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port_protocol</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the destination port or protocol.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>eq</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Match only packets on a given port number.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>range</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Match only packets in the range of port numbers</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>end</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the end of the port range</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>start</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the start of the port range</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>prefix_list</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Match IP destination prefixes in named list</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>grant</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>permit</li>
+                                                                                                                                                                                                <li>deny</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Action to take after matching condition (allow, discard/reject)</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Filter term name</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>protocol</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the protocol to match.</div>
+                                            <div>Refer to vendor documentation for valid values.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>protocol_options</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>All possible suboptions for the protocol chosen.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>icmp</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>ICMP protocol options.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dod_host_prohibited</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Host prohibited</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dod_net_prohibited</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Net prohibited</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>echo</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Echo (ping)</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>echo_reply</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Echo reply</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host_redirect</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Host redirect</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host_tos_redirect</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Host redirect for TOS</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host_tos_unreachable</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Host unreachable for TOS</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host_unknown</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Host unknown</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host_unreachable</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Host unreachable</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>net_redirect</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Network redirect</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>net_tos_redirect</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Net redirect for TOS</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>network_unknown</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Network unknown</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port_unreachable</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Port unreachable</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>protocol_unreachable</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Protocol unreachable</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>reassembly_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Reassembly timeout</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>redirect</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>All redirects</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>router_advertisement</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Router discovery advertisements</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>router_solicitation</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Router discovery solicitations</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>source_route_failed</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Source route failed</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>time_exceeded</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>All time exceeded.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ttl_exceeded</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>TTL exceeded</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>source</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the source for the filter</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>address</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>IP source address to use for the filter</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port_protocol</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the source port or protocol.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>eq</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Match only packets on a given port number.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>range</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Match only packets in the range of port numbers</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>end</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the end of the port range</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>start</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the start of the port range</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>prefix_list</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>IP source prefix list to use for the filter</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="5">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name to use for the acl filter</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="6">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>afi</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>ipv4</li>
+                                                                                                                                                                                                <li>ipv6</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Protocol family to use by the acl filter</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="7">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                                                                                                                                <li>gathered</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state the configuration should be left in</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the device being managed.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - Tested against JunOS v18.4R1
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using merged
+
+    # Before state:
+    # -------------
+    #
+    # admin# show firewall
+
+    - name: Merge JUNOS acl
+      junipernetworks.junos.junos_acls:
+        config:
+        - afi: ipv4
+          acls:
+          - name: allow_ssh_acl
+            aces:
+            - name: ssh_rule
+              source:
+                port_protocol:
+                  eq: ssh
+              protocol: tcp
+          state: merged
+
+    # After state:
+    # -------------
+    # admin# show firewall
+    # family inet {
+    #     filter allow_ssh_acl {
+    #         term ssh_rule {
+    #             from {
+    #                 protocol tcp;
+    #                 source-port ssh;
+    #             }
+    #         }
+    #     }
+    # }
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The resulting configuration model invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration prior to the model invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;command 1&#x27;, &#x27;command 2&#x27;, &#x27;command 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Daniel Mellado (@dmellado)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_banner.rst
+++ b/docs/junipernetworks.junos.junos_banner.rst
@@ -1,0 +1,363 @@
+
+.. _junipernetworks.junos.junos_banner_:
+
+
+*****
+junipernetworks.junos.junos_banner
+*****
+
+**Manage multiline banners on Juniper JUNOS devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This will configure both login and motd banners on network devices. It allows playbooks to add or remote banner text from the active running configuration.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>banner</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>login</li>
+                                                                                                                                                                                                <li>motd</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies which banner that should be configured on the remote device. Value <code>login</code> indicates system login message prior to authenticating, <code>motd</code> is login announcement after successful authentication.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is present in the current devices active running configuration.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>text</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The banner text that should be present in the remote device running configuration.  This argument accepts a multiline string, with no empty lines. Requires <em>state=present</em>.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: configure the login banner
+      junipernetworks.junos.junos_banner:
+        banner: login
+        text: |
+          this is my login banner
+          that contains a multiline
+          string
+        state: present
+
+    - name: remove the motd banner
+      junipernetworks.junos.junos_banner:
+        banner: motd
+        state: absent
+
+    - name: deactivate the motd banner
+      junipernetworks.junos.junos_banner:
+        banner: motd
+        state: present
+        active: false
+
+    - name: activate the motd banner
+      junipernetworks.junos.junos_banner:
+        banner: motd
+        state: present
+        active: true
+
+    - name: Configure banner from file
+      junipernetworks.junos.junos_banner:
+        banner: motd
+        text: "{{ lookup('file', './config_partial/raw_banner.cfg') }}"
+        state: present
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit system login] +   message &quot;this is my login banner&quot;;</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_command.rst
+++ b/docs/junipernetworks.junos.junos_command.rst
@@ -1,0 +1,475 @@
+
+.. _junipernetworks.junos.junos_command_:
+
+
+*****
+junipernetworks.junos.junos_command
+*****
+
+**Run arbitrary commands on an Juniper JUNOS device**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Sends an arbitrary set of commands to an JUNOS node and returns the results read from the device.  This module includes an argument that will cause the module to wait for a specific condition before returning or timing out if the condition is not met.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- jxmlease
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The commands to send to the remote junos device over the configured provider.  The resulting output from the command is returned.  If the <em>wait_for</em> argument is provided, the module is not returned until the condition is satisfied or the number of <em>retries</em> has been exceeded.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>display</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>text</li>
+                                                                                                                                                                                                <li>json</li>
+                                                                                                                                                                                                <li>xml</li>
+                                                                                                                                                                                                <li>set</li>
+                                                                                    </ul>
+                                                                                    <b>Default:</b><br/><div style="color: blue">"depends on input argument I(rpcs) or I(commands)"</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Encoding scheme to use when serializing output from the device. This handles how to properly understand the output and apply the conditionals path to the result set. For <em>rpcs</em> argument default display is <code>xml</code> and for <em>commands</em> argument default display is <code>text</code>. Value <code>set</code> is applicable only for fetching configuration from device.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: format, output</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>interval</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the interval in seconds to wait between retries of the command.  If the command does not pass the specified conditional, the interval indicates how to long to wait before trying the command again.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>match</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>any</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>all</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>match</em> argument is used in conjunction with the <em>wait_for</em> argument to specify the match policy.  Valid values are <code>all</code> or <code>any</code>.  If the value is set to <code>all</code> then all conditionals in the <em>wait_for</em> must be satisfied.  If the value is set to <code>any</code> then only one of the values must be satisfied.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>retries</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the number of retries a command should be tried before it is considered failed.  The command is run on the target device every retry and evaluated against the <em>wait_for</em> conditionals.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rpcs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>rpcs</code> argument accepts a list of RPCs to be executed over a netconf session and the results from the RPC execution is return to the playbook via the modules results dictionary.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>wait_for</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies what to evaluate from the output of the command and what conditionals to apply.  This argument will cause the task to wait for a particular conditional to be true before moving forward.   If the conditional is not true by the configured retries, the task fails.  See examples.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: waitfor</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``network_cli`` connections and with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: run show version on remote devices
+      junipernetworks.junos.junos_command:
+        commands: show version
+
+    - name: run show version and check to see if output contains Juniper
+      junipernetworks.junos.junos_command:
+        commands: show version
+        wait_for: result[0] contains Juniper
+
+    - name: run multiple commands on remote nodes
+      junipernetworks.junos.junos_command:
+        commands:
+        - show version
+        - show interfaces
+
+    - name: run multiple commands and evaluate the output
+      junipernetworks.junos.junos_command:
+        commands:
+        - show version
+        - show interfaces
+        wait_for:
+        - result[0] contains Juniper
+        - result[1] contains Loopback0
+
+    - name: run commands and specify the output format
+      junipernetworks.junos.junos_command:
+        commands: show version
+        display: json
+
+    - name: run rpc on the remote device
+      junipernetworks.junos.junos_command:
+        commands: show configuration
+        display: set
+
+    - name: run rpc on the remote device
+      junipernetworks.junos.junos_command:
+        rpcs: get-software-information
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>failed_conditions</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>failed</td>
+                <td>
+                                                                        <div>The list of conditionals that have failed</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;...&#x27;, &#x27;...&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>output</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>If the <em>display</em> is in <code>xml</code> format.</td>
+                <td>
+                                                                        <div>The set of transformed xml to json format from the commands responses</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;...&#x27;, &#x27;...&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stdout</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always apart from low level errors (such as action plugin)</td>
+                <td>
+                                                                        <div>The set of responses from the commands</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;...&#x27;, &#x27;...&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stdout_lines</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always apart from low level errors (such as action plugin)</td>
+                <td>
+                                                                        <div>The value of stdout split into a list</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[[&#x27;...&#x27;, &#x27;...&#x27;], [&#x27;...&#x27;], [&#x27;...&#x27;]]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Peter Sprygada (@privateip)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_config.rst
+++ b/docs/junipernetworks.junos.junos_config.rst
@@ -1,0 +1,674 @@
+
+.. _junipernetworks.junos.junos_config_:
+
+
+*****
+junipernetworks.junos.junos_config
+*****
+
+**Manage configuration on devices running Juniper JUNOS**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides an implementation for working with the active configuration running on Juniper JUNOS devices.  It provides a set of arguments for loading configuration, performing rollback operations and zeroing the active configuration on the device.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>backup</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This argument will cause the module to create a full backup of the current <code>running-config</code> from the remote device before any changes are made. If the <code>backup_options</code> value is not given, the backup file is written to the <code>backup</code> folder in the playbook root directory or role root directory, if playbook is part of an ansible role. If the directory does not exist, it is created.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>backup_options</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This is a dict object containing configurable options related to backup file path. The value of this option is read only when <code>backup</code> is set to <em>yes</em>, if <code>backup</code> is set to <em>no</em> this option will be silently ignored.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dir_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This option provides the path ending with directory name in which the backup configuration file will be stored. If the directory does not exist it will be first created and the filename is either the value of <code>filename</code> or default filename as described in <code>filename</code> options description. If the path value is not given in that case a <em>backup</em> directory will be created in the current working directory and backup configuration will be copied in <code>filename</code> within <em>backup</em> directory.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filename</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The filename to be used to store the backup configuration. If the filename is not given it will be generated based on the hostname, current time and date in format defined by &lt;hostname&gt;_config.&lt;current-date&gt;@&lt;current-time&gt;</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>check_commit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This argument will check correctness of syntax; do not apply changes.</div>
+                                            <div>Note that this argument can be used to confirm verified configuration done via commit confirmed operation</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>comment</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"configured by junos_config"</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>comment</code> argument specifies a text string to be used when committing the configuration.  If the <code>confirm</code> argument is set to False, this argument is silently ignored.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>confirm</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">0</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>confirm</code> argument will configure a time out value in minutes for the commit to be confirmed before it is automatically rolled back.  If the <code>confirm</code> argument is set to False, this argument is silently ignored.  If the value for this argument is set to 0, the commit is confirmed immediately.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>confirm_commit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This argument will execute commit operation on remote device. It can be used to confirm a previous commit.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>lines</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This argument takes a list of <code>set</code> or <code>delete</code> configuration lines to push into the remote device.  Each line must start with either <code>set</code> or <code>delete</code>.  This argument is mutually exclusive with the <em>src</em> argument.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>replace</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>replace</code> argument will instruct the remote device to replace the current configuration hierarchy with the one specified in the corresponding hierarchy of the source configuration loaded from this module.</div>
+                                            <div>Note this argument should be considered deprecated.  To achieve the equivalent, set the <em>update</em> argument to <code>replace</code>. This argument will be removed in a future release. The <code>replace</code> and <code>update</code> argument is mutually exclusive.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rollback</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>rollback</code> argument instructs the module to rollback the current configuration to the identifier specified in the argument.  If the specified rollback identifier does not exist on the remote device, the module will fail.  To rollback to the most recent commit, set the <code>rollback</code> argument to 0.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>src</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>src</em> argument provides a path to the configuration file to load into the remote system. The path can either be a full system path to the configuration file if the value starts with / or relative to the root of the implemented role or playbook. This argument is mutually exclusive with the <em>lines</em> argument.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>src_format</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>xml</li>
+                                                                                                                                                                                                <li>set</li>
+                                                                                                                                                                                                <li>text</li>
+                                                                                                                                                                                                <li>json</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>src_format</em> argument specifies the format of the configuration found int <em>src</em>.  If the <em>src_format</em> argument is not provided, the module will attempt to determine the format of the configuration file specified in <em>src</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>update</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merge</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>override</li>
+                                                                                                                                                                                                <li>replace</li>
+                                                                                                                                                                                                <li>update</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This argument will decide how to load the configuration data particularly when the candidate configuration and loaded configuration contain conflicting statements. Following are accepted values. <code>merge</code> combines the data in the loaded configuration with the candidate configuration. If statements in the loaded configuration conflict with statements in the candidate configuration, the loaded statements replace the candidate ones. <code>override</code> discards the entire candidate configuration and replaces it with the loaded configuration. <code>replace</code> substitutes each hierarchy level in the loaded configuration for the corresponding level. <code>update</code> is similar to the override option. The new configuration completely replaces the existing configuration. The difference comes when the configuration is later committed. This option performs a &#x27;diff&#x27; between the new candidate configuration and the existing committed configuration. It then only notifies system processes responsible for the changed portions of the configuration, and only marks the actual configuration changes as &#x27;changed&#x27;.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>zeroize</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>zeroize</code> argument is used to completely sanitize the remote device configuration back to initial defaults.  This argument will effectively remove all current configuration statements on the remote device.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Abbreviated commands are NOT idempotent, see `Network FAQ <../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands>`_.
+   - Loading JSON-formatted configuration *json* is supported starting in Junos OS Release 16.1 onwards.
+   - Update ``override`` not currently compatible with ``set`` notation.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: load configure file into device
+      junipernetworks.junos.junos_config:
+        src: srx.cfg
+        comment: update config
+
+    - name: load configure lines into device
+      junipernetworks.junos.junos_config:
+        lines:
+        - set interfaces ge-0/0/1 unit 0 description "Test interface"
+        - set vlans vlan01 description "Test vlan"
+        comment: update config
+
+    - name: Set routed VLAN interface (RVI) IPv4 address
+      junipernetworks.junos.junos_config:
+        lines:
+        - set vlans vlan01 vlan-id 1
+        - set interfaces irb unit 10 family inet address 10.0.0.1/24
+        - set vlans vlan01 l3-interface irb.10
+
+    - name: Check correctness of commit configuration
+      junipernetworks.junos.junos_config:
+        check_commit: yes
+
+    - name: rollback the configuration to id 10
+      junipernetworks.junos.junos_config:
+        rollback: 10
+
+    - name: zero out the current configuration
+      junipernetworks.junos.junos_config:
+        zeroize: yes
+
+    - name: Set VLAN access and trunking
+      junipernetworks.junos.junos_config:
+        lines:
+        - set vlans vlan02 vlan-id 6
+        - set interfaces ge-0/0/6.0 family ethernet-switching interface-mode access vlan
+          members vlan02
+        - set interfaces ge-0/0/6.0 family ethernet-switching interface-mode trunk vlan
+          members vlan02
+
+    - name: confirm a previous commit
+      junipernetworks.junos.junos_config:
+        confirm_commit: yes
+
+    - name: for idempotency, use full-form commands
+      junipernetworks.junos.junos_config:
+        lines:
+          # - set int ge-0/0/1 unit 0 desc "Test interface"
+        - set interfaces ge-0/0/1 unit 0 description "Test interface"
+
+    - name: configurable backup path
+      junipernetworks.junos.junos_config:
+        src: srx.cfg
+        backup: yes
+        backup_options:
+          filename: backup.cfg
+          dir_path: /home/user
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>backup_path</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when backup is yes</td>
+                <td>
+                                                                        <div>The full path to the backup file</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">/playbooks/ansible/backup/config.2016-07-16@22:28:34</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>date</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when backup is yes</td>
+                <td>
+                                                                        <div>The date extracted from the backup file name</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-07-16</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>filename</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when backup is yes and filename is not specified in backup options</td>
+                <td>
+                                                                        <div>The name of the backup file</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">junos01_config.2016-07-16@22:28:34</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>shortname</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when backup is yes and filename is not specified in backup options</td>
+                <td>
+                                                                        <div>The full path to the backup file excluding the timestamp</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">/playbooks/ansible/backup/junos01_config</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>time</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when backup is yes</td>
+                <td>
+                                                                        <div>The time extracted from the backup file name</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">22:28:34</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Peter Sprygada (@privateip)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_facts.rst
+++ b/docs/junipernetworks.junos.junos_facts.rst
@@ -1,0 +1,292 @@
+
+.. _junipernetworks.junos.junos_facts_:
+
+
+*****
+junipernetworks.junos.junos_facts
+*****
+
+**Collect facts from remote devices running Juniper Junos**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Collects fact information from a remote device running the Junos operating system.  By default, the module will collect basic fact information from the device to be included with the hostvars. Additional fact information can be collected based on the configured set of arguments.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config_format</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>xml</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>text</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>set</li>
+                                                                                                                                                                                                <li>json</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>config_format</em> argument specifies the format of the configuration when serializing output from the device. This argument is applicable only when <code>config</code> value is present in <em>gather_subset</em>. The <em>config_format</em> should be supported by the junos version running on device. This value is not applicable while fetching old style facts that is when <code>ofacts</code> value is present in value if <em>gather_subset</em> value. This option is valid only for <code>gather_subset</code> values.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>gather_network_resources</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>When supplied, this argument will restrict the facts collected to a given subset. Possible values for this argument include all and the resources like interfaces, vlans etc. Can specify a list of values to include a larger subset. Values can also be used with an initial <code><span class='module'>!</span></code> to specify that a specific subset should not be collected. Valid subsets are &#x27;all&#x27;, &#x27;interfaces&#x27;, &#x27;lacp&#x27;, &#x27;lacp_interfaces&#x27;, &#x27;lag_interfaces&#x27;, &#x27;l2_interfaces&#x27;, &#x27;l3_interfaces&#x27;, &#x27;lldp_global&#x27;, &#x27;lldp_interfaces&#x27;, &#x27;vlans&#x27;.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>gather_subset</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">["!config"]</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>When supplied, this argument will restrict the facts collected to a given subset.  Possible values for this argument include all, hardware, config, and interfaces.  Can specify a list of values to include a larger subset.  Values can also be used with an initial <code><span class='module'>!</span></code> to specify that a specific subset should not be collected. To maintain backward compatibility old style facts can be retrieved by explicitly adding <code>ofacts</code>  to value, this requires junos-eznc to be installed as a prerequisite. Valid value of gather_subset are default, hardware, config, interfaces, ofacts. If <code>ofacts</code> is present in the list it fetches the old style facts (fact keys without &#x27;ansible_&#x27; prefix) and it requires junos-eznc library to be installed on control node and the device login credentials must be given in <code>provider</code> option.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Ensure *config_format* used to retrieve configuration from device is supported by junos version running on device.
+   - With *config_format = json*, configuration in the results will be a dictionary(and not a JSON string)
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - Fetching old style facts requires junos-eznc library to be installed on control node and the device login credentials must be given in provider option.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: collect default set of facts
+      junipernetworks.junos.junos_facts:
+
+    - name: collect default set of facts and configuration
+      junipernetworks.junos.junos_facts:
+        gather_subset: config
+
+    - name: Gather legacy and resource facts
+      junipernetworks.junos.junos_facts:
+        gather_subset: all
+        gather_network_resources: all
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Nathaniel Case (@Qalthos)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_interface.rst
+++ b/docs/junipernetworks.junos.junos_interface.rst
@@ -1,0 +1,623 @@
+
+.. _junipernetworks.junos.junos_interface_:
+
+
+*****
+junipernetworks.junos.junos_interface
+*****
+
+**(deprecated) Manage Interface on Juniper JUNOS network devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+DEPRECATED
+----------
+:Removed in Ansible: version: 2.13
+:Why: Updated modules released with more functionality
+:Alternative: Use :ref:`junos_interfaces <junos_interfaces_module>` instead.
+
+
+
+Synopsis
+--------
+- This module provides declarative management of Interfaces on Juniper JUNOS network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aggregate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of Interfaces definitions.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>delay</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Time in seconds to wait before checking for the operational state on remote device. This wait is applicable for operational state argument which are <em>state</em> with values <code>up</code>/<code>down</code>, <em>tx_rate</em> and <em>rx_rate</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Description of Interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>duplex</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>full</li>
+                                                                                                                                                                                                <li>half</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>auto</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Interface link status.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enabled</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure interface link status.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mtu</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Maximum size of transmit packet.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the Interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>neighbors</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Check the operational state of given interface <code>name</code> for LLDP neighbor.</div>
+                                            <div>The following suboptions are available.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>LLDP neighbor host for given interface <code>name</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>LLDP neighbor port to which given interface <code>name</code> is connected.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rx_rate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Receiver rate in bits per second (bps).</div>
+                                            <div>This is state check parameter only.</div>
+                                            <div>Supports conditionals, see <a href='../network/user_guide/network_working_with_command_output.html'>Conditionals in Networking Modules</a></div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>speed</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Interface link speed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>up</li>
+                                                                                                                                                                                                <li>down</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>State of the Interface configuration, <code>up</code> indicates present and operationally up and <code>down</code> indicates present and operationally <code>down</code></div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>tx_rate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Transmit rate in bits per second (bps).</div>
+                                            <div>This is state check parameter only.</div>
+                                            <div>Supports conditionals, see <a href='../network/user_guide/network_working_with_command_output.html'>Conditionals in Networking Modules</a></div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: configure interface
+      junipernetworks.junos.junos_interface:
+        name: ge-0/0/1
+        description: test-interface
+
+    - name: remove interface
+      junipernetworks.junos.junos_interface:
+        name: ge-0/0/1
+        state: absent
+
+    - name: make interface down
+      junipernetworks.junos.junos_interface:
+        name: ge-0/0/1
+        enabled: false
+
+    - name: make interface up
+      junipernetworks.junos.junos_interface:
+        name: ge-0/0/1
+        enabled: true
+
+    - name: Deactivate interface config
+      junipernetworks.junos.junos_interface:
+        name: ge-0/0/1
+        state: present
+        active: false
+
+    - name: Activate interface config
+      net_interface:
+        name: ge-0/0/1
+        state: present
+        active: true
+
+    - name: Configure interface speed, mtu, duplex
+      junipernetworks.junos.junos_interface:
+        name: ge-0/0/1
+        state: present
+        speed: 1g
+        mtu: 256
+        duplex: full
+
+    - name: Create interface using aggregate
+      junipernetworks.junos.junos_interface:
+        aggregate:
+        - name: ge-0/0/1
+          description: test-interface-1
+        - name: ge-0/0/2
+          description: test-interface-2
+        speed: 1g
+        duplex: full
+        mtu: 512
+
+    - name: Delete interface using aggregate
+      junipernetworks.junos.junos_interface:
+        aggregate:
+        - name: ge-0/0/1
+        - name: ge-0/0/2
+        state: absent
+
+    - name: Check intent arguments
+      junipernetworks.junos.junos_interface:
+        name: '{{ name }}'
+        state: up
+        tx_rate: ge(0)
+        rx_rate: le(0)
+
+    - name: Check neighbor intent
+      junipernetworks.junos.junos_interface:
+        name: xe-0/1/1
+        neighbors:
+        - port: Ethernet1/0/1
+          host: netdev
+
+    - name: Config + intent
+      junipernetworks.junos.junos_interface:
+        name: '{{ name }}'
+        enabled: false
+        state: down
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit interfaces] +   ge-0/0/1 { +       description test-interface; +   }</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+- This  will be removed in version 2.13. *[deprecated]*
+- For more information see `DEPRECATED`_.
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_interfaces.rst
+++ b/docs/junipernetworks.junos.junos_interfaces.rst
@@ -1,0 +1,544 @@
+
+.. _junipernetworks.junos.junos_interfaces_:
+
+
+*****
+junipernetworks.junos.junos_interfaces
+*****
+
+**Manages interface attributes of Juniper Junos OS network devices.**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module manages the interfaces on Juniper Junos OS network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="3">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The provided configuration</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Interface description.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>duplex</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>automatic</li>
+                                                                                                                                                                                                <li>full-duplex</li>
+                                                                                                                                                                                                <li>half-duplex</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Interface link status. Applicable for Ethernet interfaces only, either in half duplex, full duplex or in automatic state which negotiates the duplex automatically.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enabled</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Administrative state of the interface.</div>
+                                            <div>Set the value to <code>true</code> to administratively enabled the interface or <code>false</code> to disable it.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hold_time</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The hold time for given interface name.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>down</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The link down hold time in milliseconds.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>up</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The link up hold time in milliseconds.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mtu</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>MTU for a specific interface.</div>
+                                            <div>Applicable for Ethernet interfaces only.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Full name of interface, e.g. ge-0/0/0.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>speed</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Interface link speed. Applicable for Ethernet interfaces only.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state of the configuration after module completion</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 18.4R1.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using deleted
+
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Configured by Ansible-1";
+    #    speed 1g;
+    #    mtu 1800
+    # }
+    # ge-0/0/2 {
+    #    description "Configured by Ansible-2";
+    #    ether-options {
+    #        auto-negotiation;
+    #    }
+    # }
+
+    - name: "Delete given options for the interface (Note: This won't delete the interface    \     itself if any other values are configured for interface)"
+      junipernetworks.junos.junos_interfaces:
+        config:
+        - name: ge-0/0/1
+          description: Configured by Ansible-1
+          speed: 1g
+          mtu: 1800
+        - name: ge-0/0/2
+          description: Configured by Ansible -2
+        state: deleted
+
+    # After state:
+    # ------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #    ether-options {
+    #        auto-negotiation;
+    #    }
+    # }
+
+
+    # Using merged
+
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "test interface";
+    #    speed 1g;
+    # }
+
+    - name: Merge provided configuration with device configuration (default operation
+        is merge)
+      junipernetworks.junos.junos_interfaces:
+        config:
+        - name: ge-0/0/1
+          description: Configured by Ansible-1
+          enabled: true
+          mtu: 1800
+        - name: ge-0/0/2
+          description: Configured by Ansible-2
+          enabled: false
+        state: merged
+
+    # After state:
+    # ------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Configured by Ansible-1";
+    #    speed 1g;
+    #    mtu 1800
+    # }
+    # ge-0/0/2 {
+    #    disable;
+    #    description "Configured by Ansible-2";
+    # }
+
+
+    # Using overridden
+
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Configured by Ansible-1";
+    #    speed 1g;
+    #    mtu 1800
+    # }
+    # ge-0/0/2 {
+    #    disable;
+    #    description "Configured by Ansible-2";
+    #    ether-options {
+    #        auto-negotiation;
+    #    }
+    # }
+    # ge-0/0/11 {
+    #    description "Configured by Ansible-11";
+    # }
+
+    - name: Override device configuration of all interfaces with provided configuration
+      junipernetworks.junos.junos_interfaces:
+        config:
+        - name: ge-0/0/2
+          description: Configured by Ansible-2
+          enabled: false
+          mtu: 2800
+        - name: ge-0/0/3
+          description: Configured by Ansible-3
+        state: overridden
+
+    # After state:
+    # ------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #    disable;
+    #    description "Configured by Ansible-2";
+    #    mtu 2800
+    # }
+    # ge-0/0/3 {
+    #    description "Configured by Ansible-3";
+    # }
+
+
+    # Using replaced
+
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Configured by Ansible-1";
+    #    speed 1g;
+    #    mtu 1800
+    # }
+    # ge-0/0/2 {
+    #    disable;
+    #    mtu 1800;
+    #    speed 1g;
+    #    description "Configured by Ansible-2";
+    #    ether-options {
+    #        auto-negotiation;
+    #    }
+    # }
+    # ge-0/0/11 {
+    #    description "Configured by Ansible-11";
+    # }
+
+    - name: Replaces device configuration of listed interfaces with provided configuration
+      junipernetworks.junos.junos_interfaces:
+        config:
+        - name: ge-0/0/2
+          description: Configured by Ansible-2
+          enabled: false
+          mtu: 2800
+        - name: ge-0/0/3
+          description: Configured by Ansible-3
+        state: replaced
+
+    # After state:
+    # ------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Configured by Ansible-1";
+    #    speed 1g;
+    #    mtu 1800
+    # }
+    # ge-0/0/2 {
+    #    disable;
+    #    description "Configured by Ansible-2";
+    #    mtu 2800
+    # }
+    # ge-0/0/3 {
+    #    description "Configured by Ansible-3";
+    # }
+    # ge-0/0/11 {
+    #    description "Configured by Ansible-11";
+    # }
+
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The configuration as structured data after module completion.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration as structured data prior to module invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>xml</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of xml rpc payload pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;xml 1&#x27;, &#x27;xml 2&#x27;, &#x27;xml 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_l2_interface.rst
+++ b/docs/junipernetworks.junos.junos_l2_interface.rst
@@ -1,0 +1,538 @@
+
+.. _junipernetworks.junos.junos_l2_interface_:
+
+
+*****
+junipernetworks.junos.junos_l2_interface
+*****
+
+**(deprecated) Manage Layer-2 interface on Juniper JUNOS network devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+DEPRECATED
+----------
+:Removed in Ansible: version: 2.13
+:Why: Updated modules released with more functionality
+:Alternative: Use :ref:`junos_l2_interfaces <junos_l2_interfaces_module>` instead.
+
+
+
+Synopsis
+--------
+- This module provides declarative management of Layer-2 interface on Juniper JUNOS network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>access_vlan</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure given VLAN in access port. The value of <code>access_vlan</code> should be vlan name.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aggregate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of Layer-2 interface definitions.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Description of Interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enhanced_layer</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>True if your device has Enhanced Layer 2 Software (ELS).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filter_input</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The name of input filter of ethernet-switching.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filter_output</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The name of output filter of ethernet-switching.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mode</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>access</li>
+                                                                                                                                                                                                <li>trunk</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Mode in which interface needs to be configured.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the interface excluding any logical unit number.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>native_vlan</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Native VLAN to be configured in trunk port. The value of <code>native_vlan</code> should be vlan id.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>State of the Layer-2 Interface configuration.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>trunk_vlans</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of VLAN names to be configured in trunk port. The value of <code>trunk_vlans</code> should be list of vlan names.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>unit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">0</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Logical interface number. Value of <code>unit</code> should be of type integer.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Configure interface in access mode
+      junipernetworks.junos.junos_l2_interface:
+        name: ge-0/0/1
+        description: interface-access
+        mode: access
+        access_vlan: red
+        active: true
+        state: present
+
+    - name: Configure interface in trunk mode
+      junipernetworks.junos.junos_l2_interface:
+        name: ge-0/0/1
+        description: interface-trunk
+        mode: trunk
+        trunk_vlans:
+        - blue
+        - green
+        native_vlan: 100
+        active: true
+        state: present
+
+    - name: Configure interface in access and trunk mode using aggregate
+      junipernetworks.junos.junos_l2_interface:
+        aggregate:
+        - name: ge-0/0/1
+          description: test-interface-access
+          mode: access
+          access_vlan: red
+        - name: ge-0/0/2
+          description: test-interface-trunk
+          mode: trunk
+          trunk_vlans:
+          - blue
+          - green
+          native_vlan: 100
+        active: true
+        state: present
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit interfaces] +   ge-0/0/1 { +       description &quot;l2 interface configured by Ansible&quot;; +       unit 0 { +           family ethernet-switching { +               interface-mode access; +               vlan { +                   members red; +               } +           } +       } +   }</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+- This  will be removed in version 2.13. *[deprecated]*
+- For more information see `DEPRECATED`_.
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_l2_interfaces.rst
+++ b/docs/junipernetworks.junos.junos_l2_interfaces.rst
@@ -1,0 +1,597 @@
+
+.. _junipernetworks.junos.junos_l2_interfaces_:
+
+
+*****
+junipernetworks.junos.junos_l2_interfaces
+*****
+
+**L2 interfaces resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides declarative management of a Layer-2 interface on Juniper JUNOS devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="3">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A dictionary of Layer-2 interface options</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>access</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure the interface as a Layer 2 access mode.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vlan</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure the access VLAN ID.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enhanced_layer</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>True if your device has Enhanced Layer 2 Software (ELS). If the l2 configuration is under <code>interface-mode</code> the value is True else if the l2 configuration is under <code>port-mode</code> value is False</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Full name of interface, e.g. ge-0/0/1.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>trunk</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure the interface as a Layer 2 trunk mode.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>allowed_vlans</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of VLANs to be configured in trunk port. It&#x27;s used as the VLAN range to ADD or REMOVE from the trunk.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>native_vlan</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Native VLAN to be configured in trunk port. It is used as the trunk native VLAN ID.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>unit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Logical interface number. Value of <code>unit</code> should be of type integer.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                                                                                                                                <li>gathered</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state of the configuration after module completion</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 18.4R1.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using deleted
+
+    # Before state:
+    # -------------
+    #
+    # ansible@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "L2 interface";
+    #    speed 1g;
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode access;
+    #            vlan {
+    #                members vlan30;
+    #            }
+    #        }
+    #    }
+    #}
+    #ge-0/0/2 {
+    #    description "non L2 interface";
+    #    unit 0 {
+    #        family inet {
+    #            address 192.168.56.14/24;
+    #        }
+    #    }
+
+    - name: "Delete L2 attributes of given interfaces (Note: This won't delete the interface    \     itself)."
+      junipernetworks.junos.junos_l2_interfaces:
+        config:
+        - name: ge-0/0/1
+        - name: ge-0/0/2
+        state: deleted
+
+    # After state:
+    # ------------
+    #
+    # ansible@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "L2 interface";
+    #    speed 1g;
+    # }
+    #ge-0/0/2 {
+    #    description "non L2 interface";
+    #    unit 0 {
+    #        family inet {
+    #            address 192.168.56.14/24;
+    #        }
+    #    }
+
+
+    # Using merged
+
+    # Before state:
+    # -------------
+    # ansible@junos01# show interfaces
+    # ge-0/0/3 {
+    #    description "test interface";
+    #    speed 1g;
+    #}
+    # ge-0/0/4 {
+    #    description interface-trunk;
+    #    native-vlan-id 100;
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode trunk;
+    #            vlan {
+    #                members [ vlan40 ];
+    #            }
+    #        }
+    #    }
+    # }
+
+    - name: Merge provided configuration with device configuration (default operation
+        is merge)
+      junipernetworks.junos.junos_l2_interfaces:
+        config:
+        - name: ge-0/0/3
+          access:
+            vlan: v101
+        - name: ge-0/0/4
+          trunk:
+            allowed_vlans:
+            - vlan30
+            native_vlan: 50
+        state: merged
+
+    # After state:
+    # ------------
+    # user@junos01# show interfaces
+    # ge-0/0/3 {
+    #    description "test interface";
+    #    speed 1g;
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode access;
+    #            vlan {
+    #                members v101;
+    #            }
+    #        }
+    #    }
+    # }
+    # ge-0/0/4 {
+    #    description interface-trunk;
+    #    native-vlan-id 50;
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode trunk;
+    #            vlan {
+    #                members [ vlan40 vlan30 ];
+    #            }
+    #        }
+    #    }
+    # }
+
+
+    # Using overridden
+
+    # Before state:
+    # -------------
+    # ansible@junos01# show interfaces
+    # ge-0/0/3 {
+    #    description "test interface";
+    #    speed 1g;
+    #}
+    # ge-0/0/4 {
+    #    description interface-trunk;
+    #    native-vlan-id 100;
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode trunk;
+    #            vlan {
+    #                members [ vlan40 ];
+    #            }
+    #        }
+    #    }
+    # }
+    # ge-0/0/5 {
+    #    description "Configured by Ansible-11";
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode access;
+    #            vlan {
+    #                members v101;
+    #            }
+    #        }
+    #    }
+    # }
+
+    - name: Override provided configuration with device configuration
+      junipernetworks.junos.junos_l2_interfaces:
+        config:
+        - name: ge-0/0/3
+          access:
+            vlan: v101
+        - name: ge-0/0/4
+          trunk:
+            allowed_vlans:
+            - vlan30
+            native_vlan: 50
+        state: overridden
+
+    # After state:
+    # ------------
+    # user@junos01# show interfaces
+    # ge-0/0/3 {
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode access;
+    #            vlan {
+    #                members v101;
+    #            }
+    #        }
+    #    }
+    # }
+    # ge-0/0/4 {
+    #    description interface-trunk;
+    #    native-vlan-id 50;
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode trunk;
+    #            vlan {
+    #                members [ vlan30 ];
+    #            }
+    #        }
+    #    }
+    # }
+
+
+    # Using replaced
+
+    # Before state:
+    # -------------
+    # ansible@junos01# show interfaces
+    # ge-0/0/3 {
+    #    description "test interface";
+    #    speed 1g;
+    #}
+    # ge-0/0/4 {
+    #    description interface-trunk;
+    #    native-vlan-id 100;
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode trunk;
+    #            vlan {
+    #                members [ vlan40 ];
+    #            }
+    #        }
+    #    }
+    # }
+
+    - name: Replace provided configuration with device configuration
+      junipernetworks.junos.junos_l2_interfaces:
+        config:
+        - name: ge-0/0/3
+          access:
+            vlan: v101
+        - name: ge-0/0/4
+          trunk:
+            allowed_vlans:
+            - vlan30
+            native_vlan: 50
+        state: replaced
+
+    # After state:
+    # ------------
+    # user@junos01# show interfaces
+    # ge-0/0/3 {
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode access;
+    #            vlan {
+    #                members v101;
+    #            }
+    #        }
+    #    }
+    # }
+    # ge-0/0/4 {
+    #    description interface-trunk;
+    #    native-vlan-id 50;
+    #    unit 0 {
+    #        family ethernet-switching {
+    #            interface-mode trunk;
+    #            vlan {
+    #                members [ vlan30 ];
+    #            }
+    #        }
+    #    }
+    # }
+
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The configuration as structured data after module completion.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration as structured data prior to module invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;command 1&#x27;, &#x27;command 2&#x27;, &#x27;command 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_l3_interface.rst
+++ b/docs/junipernetworks.junos.junos_l3_interface.rst
@@ -1,0 +1,486 @@
+
+.. _junipernetworks.junos.junos_l3_interface_:
+
+
+*****
+junipernetworks.junos.junos_l3_interface
+*****
+
+**(deprecated) Manage L3 interfaces on Juniper JUNOS network devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+DEPRECATED
+----------
+:Removed in Ansible: version: 2.13
+:Why: Updated modules released with more functionality
+:Alternative: Use :ref:`junos_l3_interfaces <junos_l3_interfaces_module>` instead.
+
+
+
+Synopsis
+--------
+- This module provides declarative management of L3 interfaces on Juniper JUNOS network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aggregate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of L3 interfaces definitions</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filter6_input</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The name of input filter for ipv6.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filter6_output</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The name of output filter for ipv6.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filter_input</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The name of input filter.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filter_output</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The name of output filter.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ipv4</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>IPv4 of the L3 interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ipv6</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>IPv6 of the L3 interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the L3 interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>State of the L3 interface configuration.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>unit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">0</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Logical interface number.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Set ge-0/0/1 IPv4 address
+      junipernetworks.junos.junos_l3_interface:
+        name: ge-0/0/1
+        ipv4: 192.168.0.1
+
+    - name: Remove ge-0/0/1 IPv4 address
+      junipernetworks.junos.junos_l3_interface:
+        name: ge-0/0/1
+        state: absent
+
+    - name: Set ipv4 address using aggregate
+      junipernetworks.junos.junos_l3_interface:
+        aggregate:
+        - name: ge-0/0/1
+          ipv4: 192.0.2.1
+        - name: ge-0/0/2
+          ipv4: 192.0.2.2
+          ipv6: fd5d:12c9:2201:2::2
+
+    - name: Delete ipv4 address using aggregate
+      junipernetworks.junos.junos_l3_interface:
+        aggregate:
+        - name: ge-0/0/1
+          ipv4: 192.0.2.1
+        - name: ge-0/0/2
+          ipv4: 192.0.2.2
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit interfaces ge-0/0/1 unit 0 family inet] +       address 192.0.2.1/32; [edit interfaces ge-0/0/1 unit 0 family inet6] +       address fd5d:12c9:2201:1::1/128;</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+- This  will be removed in version 2.13. *[deprecated]*
+- For more information see `DEPRECATED`_.
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_l3_interfaces.rst
+++ b/docs/junipernetworks.junos.junos_l3_interfaces.rst
@@ -1,0 +1,524 @@
+
+.. _junipernetworks.junos.junos_l3_interfaces_:
+
+
+*****
+junipernetworks.junos.junos_l3_interfaces
+*****
+
+**L3 interfaces resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides declarative management of a Layer 3 interface on Juniper JUNOS devices
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="3">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A dictionary of Layer 3 interface options</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ipv4</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>IPv4 addresses to be set for the Layer 3 logical interface mentioned in <em>name</em> option. The address format is &lt;ipv4 address&gt;/&lt;mask&gt;. The mask is number in range 0-32 for example, 192.0.2.1/24, or <code>dhcp</code> to query DHCP for an IP address</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>address</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>IPv4 address to be set for the specific interface</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ipv6</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>IPv6 addresses to be set for the Layer 3 logical interface mentioned in <em>name</em> option. The address format is &lt;ipv6 address&gt;/&lt;mask&gt;, the mask is number in range 0-128 for example, 2001:db8:2201:1::1/64 or <code>auto-config</code> to use SLAAC</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>address</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>IPv6 address to be set for the specific interface</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Full name of interface, e.g. ge-0/0/1</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>unit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">0</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Logical interface number. Value of <code>unit</code> should be of type integer</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state of the configuration after module completion</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the device being managed.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - Tested against JunOS v18.4R1
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using deleted
+
+    # Before state:
+    # -------------
+    #
+    # admin# show interfaces
+    # ge-0/0/1 {
+    #     description "L3 interface";
+    #     unit 0 {
+    #         family inet {
+    #             address 10.200.16.10/24;
+    #         }
+    #     }
+    # }
+    # ge-0/0/2 {
+    #     description "non L3 interface";
+    #     unit 0 {
+    #         family ethernet-switching {
+    #             interface-mode access;
+    #             vlan {
+    #                 members 2;
+    #             }
+    #         }
+    #     }
+    # }
+
+    - name: Delete JUNOS L3 logical interface
+      junipernetworks.junos.junos_l3_interfaces:
+        config:
+        - name: ge-0/0/1
+        - name: ge-0/0/2
+      state: deleted
+    - name: Merge provided configuration with device configuration (default operation
+        is merge)
+      junipernetworks.junos.junos_l3_interfaces:
+        config:
+        - name: ge-0/0/1
+          ipv4:
+          - address: 192.168.1.10/24
+          ipv6:
+          - address: 8d8d:8d01::1/64
+        - name: ge-0/0/2
+          ipv4:
+          - address: dhcp
+        state: merged
+
+    # After state:
+    # ------------
+    #
+    # admin# show interfaces
+    # ge-0/0/1 {
+    #     description "L3 interface";
+    #     unit 0 {
+    #         family inet {
+    #             address 10.200.16.10/24;
+    #             address 192.168.1.10/24;
+    #         }
+    #         family inet6 {
+    #             address 8d8d:8d01::1/64;
+    #         }
+    #     }
+    # }
+    # ge-0/0/2 {
+    #     description "L3 interface with dhcp";
+    #     unit 0 {
+    #         family inet {
+    #             dhcp;
+    #         }
+    #     }
+    # }
+
+
+    # Using overridden
+
+    # Before state
+    # ------------
+    #
+    # admin# show interfaces
+    # ge-0/0/1 {
+    #     description "L3 interface";
+    #     unit 0 {
+    #         family inet {
+    #             address 10.200.16.10/24;
+    #         }
+    #     }
+    # }
+    # ge-0/0/2 {
+    #     description "L3 interface with dhcp";
+    #     unit 0 {
+    #         family inet {
+    #             dhcp;
+    #         }
+    #     }
+    # }
+    # ge-0/0/3 {
+    #     description "another L3 interface";
+    #     unit 0 {
+    #         family inet {
+    #             address 192.168.1.10/24;
+    #         }
+    #     }
+    # }
+
+    - name: Override provided configuration with device configuration
+      junipernetworks.junos.junos_l3_interfaces:
+        config:
+        - name: ge-0/0/1
+          ipv4:
+          - address: 192.168.1.10/24
+          ipv6:
+          - address: 8d8d:8d01::1/64
+        - name: ge-0/0/2
+          ipv6:
+          - address: 2001:db8:3000::/64
+        state: overridden
+
+    # After state:
+    # ------------
+    #
+    # admin# show interfaces
+    # ge-0/0/1 {
+    #     description "L3 interface";
+    #     unit 0 {
+    #         family inet {
+    #             address 192.168.1.10/24;
+    #         }
+    #         family inet6 {
+    #             address 8d8d:8d01::1/64;
+    #         }
+    #     }
+    # }
+    # ge-0/0/2 {
+    #     description "L3 interface with ipv6";
+    #     unit 0 {
+    #         family inet6 {
+    #             address 2001:db8:3000::/64;
+    #         }
+    #     }
+    # }
+    # ge-0/0/3 {
+    #     description "overridden L3 interface";
+    #     unit 0;
+    # }
+
+
+    # Using replaced
+
+    # Before state
+    # ------------
+    #
+    # admin# show interfaces
+    # ge-0/0/1 {
+    #     description "L3 interface";
+    #     unit 0 {
+    #         family inet {
+    #             address 10.200.16.10/24;
+    #         }
+    #     }
+    # }
+    # ge-0/0/2 {
+    #     description "non configured interface";
+    #     unit 0;
+    # }
+    # ge-0/0/3 {
+    #     description "another L3 interface";
+    #     unit 0 {
+    #         family inet {
+    #             address 192.168.1.10/24;
+    #         }
+    #     }
+    # }
+
+    - name: Replace provided configuration with device configuration
+      junipernetworks.junos.junos_l3_interfaces:
+        config:
+        - name: ge-0/0/1
+          ipv4:
+          - address: 192.168.1.10/24
+          ipv6:
+          - address: 8d8d:8d01::1/64
+        - name: ge-0/0/2
+          ipv4:
+          - address: dhcp
+        state: replaced
+
+    # After state:
+    # ------------
+    #
+    # admin# show interfaces
+    # ge-0/0/1 {
+    #     description "L3 interface";
+    #     unit 0 {
+    #         family inet {
+    #             address 192.168.1.10/24;
+    #         }
+    #         family inet6 {
+    #             address 8d8d:8d01::1/64;
+    #         }
+    #     }
+    # }
+    # ge-0/0/2 {
+    #     description "L3 interface with dhcp";
+    #     unit 0 {
+    #         family inet {
+    #             dhcp;
+    #         }
+    #     }
+    # }
+    # ge-0/0/3 {
+    #     description "another L3 interface";
+    #     unit 0 {
+    #         family inet {
+    #             address 192.168.1.10/24;
+    #         }
+    #     }
+    # }
+
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The configuration as structured data after module completion.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration as structured data prior to module invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;command 1&#x27;, &#x27;command 2&#x27;, &#x27;command 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Daniel Mellado (@dmellado)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_lacp.rst
+++ b/docs/junipernetworks.junos.junos_lacp.rst
@@ -1,0 +1,299 @@
+
+.. _junipernetworks.junos.junos_lacp_:
+
+
+*****
+junipernetworks.junos.junos_lacp
+*****
+
+**Manage Global Link Aggregation Control Protocol (LACP) on Juniper Junos devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides declarative management of global LACP on Juniper Junos network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A dictionary of LACP global options</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>link_protection</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>revertive</li>
+                                                                                                                                                                                                <li>non-revertive</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Enable LACP link-protection for the system. If the value is set to <code>non-revertive</code> it will not revert links when a better priority link comes up. By default the link will be reverted.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>system_priority</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>LACP priority for the system.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state of the configuration after module completion</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 18.1R1.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using deleted
+
+    # Before state:
+    # -------------
+    # user@junos01# show chassis aggregated-devices ethernet lacp
+    # system-priority 63;
+    # link-protection {
+    #    non-revertive;
+    # }
+
+    - name: Delete global LACP attributes
+      junipernetworks.junos.junos_lacp:
+        state: deleted
+
+    # After state:
+    # ------------
+    # user@junos01# show chassis aggregated-devices ethernet lacp
+    #
+
+
+    # Using merged
+
+    # Before state:
+    # -------------
+    # user@junos01# show chassis aggregated-devices ethernet lacp
+    #
+
+    - name: Merge global LACP attributes
+      junipernetworks.junos.junos_lacp:
+        config:
+          system_priority: 63
+          link_protection: revertive
+        state: merged
+
+    # After state:
+    # ------------
+    # user@junos01# show chassis aggregated-devices ethernet lacp
+    # system-priority 63;
+    # link-protection {
+    #    non-revertive;
+    # }
+
+
+    # Using replaced
+
+    # Before state:
+    # -------------
+    # user@junos01# show chassis aggregated-devices ethernet lacp
+    # system-priority 63;
+    # link-protection {
+    #    non-revertive;
+    # }
+
+    - name: Replace global LACP attributes
+      junipernetworks.junos.junos_lacp:
+        config:
+          system_priority: 30
+          link_protection: non-revertive
+        state: replaced
+
+    # After state:
+    # ------------
+    # user@junos01# show chassis aggregated-devices ethernet lacp
+    # system-priority 30;
+    # link-protection;
+
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The configuration as structured data after module completion.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration as structured data prior to module invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>xml</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of xml rpc payload pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;xml 1&#x27;, &#x27;xml 2&#x27;, &#x27;xml 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_lacp_interfaces.rst
+++ b/docs/junipernetworks.junos.junos_lacp_interfaces.rst
@@ -1,0 +1,715 @@
+
+.. _junipernetworks.junos.junos_lacp_interfaces_:
+
+
+*****
+junipernetworks.junos.junos_lacp_interfaces
+*****
+
+**LACP interfaces resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module manages Link Aggregation Control Protocol (LACP) attributes of interfaces on Juniper JUNOS devices.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="4">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The list of dictionaries of LACP interfaces options.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force_up</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This is a boolean argument to control if the port should be up in absence of received link Aggregation Control Protocol Data Unit (LACPDUS). This value is applicable for member interfaces only.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name Identifier of the interface or link aggregation group.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>period</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>fast</li>
+                                                                                                                                                                                                <li>slow</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Timer interval for periodic transmission of LACP packets. If the value is set to <code>fast</code> the packets are received every second and if the value is <code>slow</code> the packets are received every 30 seconds. This value is applicable for aggregate interface only.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port_priority</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Priority of the member port. This value is applicable for member interfaces only.</div>
+                                            <div>Refer to vendor documentation for valid values.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sync_reset</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>disable</li>
+                                                                                                                                                                                                <li>enable</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The argument notifies minimum-link failure out of sync to peer. If the value is <code>disable</code> it disables minimum-link failure handling at LACP level and if value is <code>enable</code> it enables minimum-link failure handling at LACP level. This value is applicable for aggregate interface only.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>system</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This dict object contains configurable options related to LACP system parameters for the link aggregation group. This value is applicable for aggregate interface only.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mac</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the system ID to use in LACP negotiations for the bundle, encoded as a MAC address.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>address</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The system ID to use in LACP negotiations.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>priority</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the system priority to use in LACP negotiations for the bundle.</div>
+                                            <div>Refer to vendor documentation for valid values.</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state of the configuration after module completion.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using merged
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #     ether-options {
+    #         802.3ad ae4;
+    #     }
+    # }
+    # ge-0/0/3 {
+    #    ether-options {
+    #         802.3ad ae0;
+    #     }
+    # }
+    # ae0 {
+    #     description "lag interface merged";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #         }
+    #     }
+    # }
+    # ae4 {
+    #     description "test aggregate interface";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             link-protection;
+    #         }
+    #     }
+    # }
+
+    - name: Merge provided configuration with device configuration
+      junipernetworks.junos.junos_lacp_interfaces:
+        config:
+        - name: ae0
+          period: fast
+          sync_reset: enable
+          system:
+            priority: 100
+            mac:
+              address: 00:00:00:00:00:02
+        - name: ge-0/0/3
+          port_priority: 100
+          force_up: true
+        state: merged
+
+    # After state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #     ether-options {
+    #         802.3ad ae4;
+    #     }
+    # }
+    # ge-0/0/3 {
+    #     ether-options {
+    #         802.3ad {
+    #             lacp {
+    #                 force-up;
+    #                 port-priority 100;
+    #             }
+    #             ae0;
+    #         }
+    #     }
+    # }
+    # ae0 {
+    #     description "lag interface merged";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             periodic fast;
+    #             sync-reset enable;
+    #             system-priority 100;
+    #             system-id 00:00:00:00:00:02;
+    #         }
+    #     }
+    # }
+    # ae4 {
+    #     description "test aggregate interface";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             link-protection;
+    #         }
+    #     }
+    # }
+
+    # Using replaced
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #     ether-options {
+    #         802.3ad ae4;
+    #     }
+    # }
+    # ge-0/0/3 {
+    #     ether-options {
+    #         802.3ad {
+    #             lacp {
+    #                 force-up;
+    #                 port-priority 100;
+    #             }
+    #             ae0;
+    #         }
+    #     }
+    # }
+    # ae0 {
+    #     description "lag interface merged";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             periodic fast;
+    #             sync-reset enable;
+    #             system-priority 100;
+    #             system-id 00:00:00:00:00:02;
+    #         }
+    #     }
+    # }
+    # ae4 {
+    #     description "test aggregate interface";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             link-protection;
+    #         }
+    #     }
+    # }
+
+    - name: Replace device LACP interfaces configuration with provided configuration
+      junipernetworks.junos.junos_lacp_interfaces:
+        config:
+        - name: ae0
+          period: slow
+        state: replaced
+
+    # After state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #     ether-options {
+    #         802.3ad ae4;
+    #     }
+    # }
+    # ge-0/0/3 {
+    #     ether-options {
+    #         802.3ad {
+    #             lacp {
+    #                 force-up;
+    #                 port-priority 100;
+    #             }
+    #             ae0;
+    #         }
+    #     }
+    # }
+    # ae0 {
+    #     description "lag interface merged";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             periodic slow;
+    #         }
+    #     }
+    # }
+    # ae4 {
+    #     description "test aggregate interface";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             link-protection;
+    #         }
+    #     }
+    # }
+
+    # Using overridden
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #     ether-options {
+    #         802.3ad ae4;
+    #     }
+    # }
+    # ge-0/0/3 {
+    #     ether-options {
+    #         802.3ad {
+    #             lacp {
+    #                 force-up;
+    #                 port-priority 100;
+    #             }
+    #             ae0;
+    #         }
+    #     }
+    # }
+    # ae0 {
+    #     description "lag interface merged";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             periodic slow;
+    #         }
+    #     }
+    # }
+    # ae4 {
+    #     description "test aggregate interface";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             link-protection;
+    #         }
+    #     }
+    # }
+
+    - name: Overrides all device LACP interfaces configuration with provided configuration
+      junipernetworks.junos.junos_lacp_interfaces:
+        config:
+        - name: ae0
+          system:
+            priority: 300
+            mac:
+              address: 00:00:00:00:00:03
+        - name: ge-0/0/2
+          port_priority: 200
+          force_up: false
+        state: overridden
+
+    # After state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #     ether-options {
+    #         802.3ad {
+    #             lacp {
+    #                 port-priority 200;
+    #             }
+    #             ae4;
+    #         }
+    #     }
+    # }
+    # ge-0/0/3 {
+    #     ether-options {
+    #         802.3ad {
+    #             lacp {
+    #                 force-up;
+    #                 port-priority 100;
+    #             }
+    #             ae0;
+    #         }
+    #     }
+    # }
+    # ae0 {
+    #     description "lag interface merged";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             system-priority 300;
+    #             system-id 00:00:00:00:00:03;
+    #         }
+    #     }
+    # }
+    # ae4 {
+    #     description "test aggregate interface";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             link-protection;
+    #         }
+    #     }
+    # }
+
+    # Using deleted
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #     ether-options {
+    #         802.3ad {
+    #             lacp {
+    #                 port-priority 200;
+    #             }
+    #             ae4;
+    #         }
+    #     }
+    # }
+    # ge-0/0/3 {
+    #     ether-options {
+    #         802.3ad {
+    #             lacp {
+    #                 force-up;
+    #                 port-priority 100;
+    #             }
+    #             ae0;
+    #         }
+    #     }
+    # }
+    # ae0 {
+    #     description "lag interface merged";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             system-priority 300;
+    #             system-id 00:00:00:00:00:03;
+    #         }
+    #     }
+    # }
+    # ae4 {
+    #     description "test aggregate interface";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             link-protection;
+    #         }
+    #     }
+    # }
+
+    - name: "Delete LACP interfaces attributes of given interfaces (Note: This won't delete    \     the interface itself)"
+      junipernetworks.junos.junos_lacp_interfaces:
+        config:
+        - name: ae0
+        - name: ge-0/0/3
+        - name: ge-0/0/2
+        state: deleted
+
+    # After state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/2 {
+    #     ether-options {
+    #         802.3ad ae4;
+    #     }
+    # }
+    # ge-0/0/3 {
+    #    ether-options {
+    #         802.3ad ae0;
+    #     }
+    # }
+    # ae0 {
+    #     description "lag interface merged";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #         }
+    #     }
+    # }
+    # ae4 {
+    #     description "test aggregate interface";
+    #     aggregated-ether-options {
+    #         lacp {
+    #             passive;
+    #             link-protection;
+    #         }
+    #     }
+    # }
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The configuration as structured data after module completion.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration as structured data prior to module invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;command 1&#x27;, &#x27;command 2&#x27;, &#x27;command 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_lag_interfaces.rst
+++ b/docs/junipernetworks.junos.junos_lag_interfaces.rst
@@ -1,0 +1,515 @@
+
+.. _junipernetworks.junos.junos_lag_interfaces_:
+
+
+*****
+junipernetworks.junos.junos_lag_interfaces
+*****
+
+**Manage Link Aggregation on Juniper JUNOS devices.**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module manages properties of Link Aggregation Group on Juniper JUNOS devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="3">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A list of link aggregation group configurations.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>link_protection</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This boolean option indicates if link protection should be enabled for the LAG interface. If value is <code>True</code> link protection is enabled on LAG and if value is <code>False</code> link protection is disabled.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>members</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of member interfaces of the link aggregation group. The value can be single interface or list of interfaces.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>link_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>primary</li>
+                                                                                                                                                                                                <li>backup</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The value of this options configures the member link as either <code>primary</code> or <code>backup</code>. Value <code>primary</code> configures primary interface for link-protection mode and <code>backup</code> configures backup interface for link-protection mode.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>member</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the member interface.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mode</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>active</li>
+                                                                                                                                                                                                <li>passive</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>LAG mode. A value of <code>passive</code> will enable LACP in <code>passive</code> mode that is it will respond to LACP packets and <code>active</code> configures the link to initiate transmission of LACP packets.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the link aggregation group (LAG).</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state of the configuration after module completion</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 18.4R1.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using merged
+
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Ansible configured interface 1";
+    #    ether-options {
+    #        802.3ad ae0;
+    #    }
+    # }
+    # ge-0/0/2 {
+    #    description "Ansible configured interface 2";
+    #    ether-options {
+    #        802.3ad ae0;
+    #    }
+    # }
+    # ae0 {
+    #     description "lag interface";
+    # }
+    # ae1 {
+    #     description "lag interface 1";
+    # }
+
+    - name: "Delete LAG attributes of given interfaces (Note: This won't delete the interface    \     itself)"
+      junipernetworks.junos.junos_lag_interfaces:
+        config:
+        - name: ae0
+        - name: ae1
+        state: deleted
+
+    # After state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Ansible configured interface 1";
+    # }
+    # ge-0/0/2 {
+    #    description "Ansible configured interface 2";
+    # }
+
+
+    # Using merged
+
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Ansible configured interface 1";
+    # }
+    # ge-0/0/2 {
+    #    description "Ansible configured interface 2";
+    # }
+
+    - name: Merge provided configuration with device configuration
+      junipernetworks.junos.junos_lag_interfaces:
+        config:
+        - name: ae0
+          members:
+          - member: ge-0/0/1
+            link_type: primary
+          - member: ge-0/0/2
+            link_type: backup
+        state: merged
+
+    # After state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Ansible configured interface 1";
+    #    ether-options {
+    #        802.3ad {
+    #            ae0;
+    #            primary;
+    #        }
+    #    }
+    # }
+    # ge-0/0/2 {
+    #    description "Ansible configured interface 2";
+    #    ether-options {
+    #        802.3ad {
+    #            ae0;
+    #            backup;
+    #        }
+    #    }
+    # }
+
+
+    # Using merged
+
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Ansible configured interface 1";
+    #    ether-options {
+    #        802.3ad ae0;
+    #    }
+    # }
+    # ge-0/0/2 {
+    #    description "Ansible configured interface 2";
+    #    ether-options {
+    #        802.3ad ae0;
+    #    }
+    # }
+    # ae0 {
+    #     description "lag interface";
+    # }
+    # ae3 {
+    #     description "lag interface 3";
+    # }
+
+    - name: Overrides all device LAG configuration with provided configuration
+      junipernetworks.junos.junos_lag_interfaces:
+        config:
+        - name: ae0
+          members:
+          - member: ge-0/0/2
+        - name: ae1
+          members:
+          - member: ge-0/0/1
+          mode: passive
+        state: overridden
+
+    # After state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Ansible configured interface 1";
+    #    ether-options {
+    #        802.3ad ae1;
+    #    }
+    # }
+    # ge-0/0/2 {
+    #    description "Ansible configured interface 2";
+    #    ether-options {
+    #        802.3ad ae0;
+    #    }
+    # }
+    # ae0 {
+    #     description "lag interface";
+    # }
+    # ae1 {
+    #    aggregated-ether-options {
+    #        lacp {
+    #            active;
+    #        }
+    #    }
+    # }
+
+
+    # Using merged
+
+    # Before state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Ansible configured interface 1";
+    # }
+    # ge-0/0/2 {
+    #    description "Ansible configured interface 2";
+    # }
+    # ge-0/0/3 {
+    #    description "Ansible configured interface 3";
+    # }
+
+    - name: Replace device LAG configuration with provided configuration
+      junipernetworks.junos.junos_lag_interfaces:
+        config:
+        - name: ae0
+          members:
+          - member: ge-0/0/1
+          mode: active
+        state: replaced
+
+    # After state:
+    # -------------
+    # user@junos01# show interfaces
+    # ge-0/0/1 {
+    #    description "Ansible configured interface 1";
+    #    ether-options {
+    #        802.3ad ae0;
+    #    }
+    # }
+    # ge-0/0/2 {
+    #    description "Ansible configured interface 2";
+    # }
+    # ae0 {
+    #    aggregated-ether-options {
+    #        lacp {
+    #            active;
+    #        }
+    #    }
+    # }
+    # ge-0/0/3 {
+    #    description "Ansible configured interface 3";
+    # }
+
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The configuration as structured data after module completion.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration as structured data prior to module invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>xml</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of xml rpc payload pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;xml 1&#x27;, &#x27;xml 2&#x27;, &#x27;xml 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_linkagg.rst
+++ b/docs/junipernetworks.junos.junos_linkagg.rst
@@ -1,0 +1,488 @@
+
+.. _junipernetworks.junos.junos_linkagg_:
+
+
+*****
+junipernetworks.junos.junos_linkagg
+*****
+
+**(deprecated) Manage link aggregation groups on Juniper JUNOS network devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+DEPRECATED
+----------
+:Removed in Ansible: version: 2.13
+:Why: Updated modules released with more functionality
+:Alternative: Use :ref:`junos_lag_interfaces <junos_lag_interfaces_module>` instead.
+
+
+
+Synopsis
+--------
+- This module provides declarative management of link aggregation groups on Juniper JUNOS network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aggregate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of link aggregation definitions.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Description of Interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>device_count</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Number of aggregated ethernet devices that can be configured. Acceptable integer value is between 1 and 128.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>members</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of members interfaces of the link aggregation group. The value can be single interface or list of interfaces.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>min_links</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Minimum members that should be up before bringing up the link aggregation group.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mode</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                                                                                    <li>yes</li>
+                                                                                                                                                                                                                                                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>active</li>
+                                                                                                                                                                                                <li>passive</li>
+                                                                                    </ul>
+                                                                                    <b>Default:</b><br/><div style="color: blue">"no"</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Mode of the link aggregation group. A value of <code>on</code> will enable LACP in <code>passive</code> mode. <code>active</code> configures the link to actively information about the state of the link, or it can be configured in <code>passive</code> mode ie. send link state information only when received them from another link. A value of <code>off</code> will disable LACP.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the link aggregation group.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>up</li>
+                                                                                                                                                                                                <li>down</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>State of the link aggregation group.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: configure link aggregation
+      junipernetworks.junos.junos_linkagg:
+        name: ae11
+        members:
+        - ge-0/0/5
+        - ge-0/0/6
+        - ge-0/0/7
+        lacp: active
+        device_count: 4
+        state: present
+
+    - name: delete link aggregation
+      junipernetworks.junos.junos_linkagg:
+        name: ae11
+        members:
+        - ge-0/0/5
+        - ge-0/0/6
+        - ge-0/0/7
+        lacp: active
+        device_count: 4
+        state: delete
+
+    - name: deactivate link aggregation
+      junipernetworks.junos.junos_linkagg:
+        name: ae11
+        members:
+        - ge-0/0/5
+        - ge-0/0/6
+        - ge-0/0/7
+        lacp: active
+        device_count: 4
+        state: present
+        active: false
+
+    - name: Activate link aggregation
+      junipernetworks.junos.junos_linkagg:
+        name: ae11
+        members:
+        - ge-0/0/5
+        - ge-0/0/6
+        - ge-0/0/7
+        lacp: active
+        device_count: 4
+        state: present
+        active: true
+
+    - name: Disable link aggregation
+      junipernetworks.junos.junos_linkagg:
+        name: ae11
+        state: down
+
+    - name: Enable link aggregation
+      junipernetworks.junos.junos_linkagg:
+        name: ae11
+        state: up
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit interfaces] +   ge-0/0/6 { +       ether-options { +           802.3ad ae0; +       } +   } [edit interfaces ge-0/0/7] +   ether-options { +       802.3ad ae0; +   } [edit interfaces] +   ae0 { +       description &quot;configured by junos_linkagg&quot;; +       aggregated-ether-options { +           lacp { +               active; +           } +       } +   }</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+- This  will be removed in version 2.13. *[deprecated]*
+- For more information see `DEPRECATED`_.
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_lldp.rst
+++ b/docs/junipernetworks.junos.junos_lldp.rst
@@ -1,0 +1,379 @@
+
+.. _junipernetworks.junos.junos_lldp_:
+
+
+*****
+junipernetworks.junos.junos_lldp
+*****
+
+**(deprecated) Manage LLDP configuration on Juniper JUNOS network devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+DEPRECATED
+----------
+:Removed in Ansible: version: 2.13
+:Why: Updated modules released with more functionality
+:Alternative: Use :ref:`junos_lldp_global <junos_lldp_global_module>` instead.
+
+
+
+Synopsis
+--------
+- This module provides declarative management of LLDP service on Juniper JUNOS network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hold_multiplier</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the number of seconds that LLDP information is held before it is discarded. The multiplier value is used in combination with the <code>interval</code> value.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>interval</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Frequency at which LLDP advertisements are sent (in seconds).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>enabled</li>
+                                                                                                                                                                                                <li>disabled</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Value of <code>present</code> ensures given LLDP configuration is present on device and LLDP is enabled, for value of <code>absent</code> LLDP configuration is deleted and LLDP is in disabled state. Value <code>enabled</code> ensures LLDP protocol is enabled and LLDP configuration if any is configured on remote device, for value of <code>disabled</code> it ensures LLDP protocol is disabled any LLDP configuration if any is still present.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>transmit_delay</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the number of seconds the device waits before sending advertisements to neighbors after a change is made in local system.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Enable LLDP service
+      junipernetworks.junos.junos_lldp:
+        state: enabled
+
+    - name: Disable LLDP service
+      junipernetworks.junos.junos_lldp:
+        state: disabled
+
+    - name: Set LLDP parameters
+      junipernetworks.junos.junos_lldp:
+        interval: 10
+        hold_multiplier: 5
+        transmit_delay: 30
+        state: present
+
+    - name: Delete LLDP parameters
+      junipernetworks.junos.junos_lldp:
+        interval: 10
+        hold_multiplier: 5
+        transmit_delay: 30
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit] +  protocols { +      lldp { +          disable; +      } +  }</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+- This  will be removed in version 2.13. *[deprecated]*
+- For more information see `DEPRECATED`_.
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_lldp_global.rst
+++ b/docs/junipernetworks.junos.junos_lldp_global.rst
@@ -1,0 +1,348 @@
+
+.. _junipernetworks.junos.junos_lldp_global_:
+
+
+*****
+junipernetworks.junos.junos_lldp_global
+*****
+
+**LLDP resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module manages link layer discovery protocol (LLDP) attributes on Juniper JUNOS devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The list of link layer discovery protocol attribute configurations</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>address</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This argument sets the management address from LLDP.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enabled</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This argument is a boolean value to enabled or disable LLDP.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hold_multiplier</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the number of seconds that LLDP information is held before it is discarded. The multiplier value is used in combination with the <code>interval</code> value.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>interval</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Frequency at which LLDP advertisements are sent (in seconds).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>transmit_delay</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specify the number of seconds the device waits before sending advertisements to neighbors after a change is made in local system.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                                                                                                                                <li>gathered</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state of the configuration after module completion.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 18.4R1.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using merged
+    # Before state:
+    # -------------
+    # user@junos01# # show protocols lldp
+    #
+    - name: Merge provided configuration with device configuration
+      junipernetworks.junos.junos_lldp_global:
+        config:
+          interval: 10000
+          address: 10.1.1.1
+          transmit_delay: 400
+          hold_multiplier: 10
+        state: merged
+
+    # After state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+    # transmit-delay 400;
+    # hold-multiplier 10;
+
+    # Using replaced
+    # Before state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+    # transmit-delay 400;
+    # hold-multiplier 10;
+
+    - name: Replace provided configuration with device configuration
+      junipernetworks.junos.junos_lldp_global:
+        config:
+          address: 20.2.2.2
+          hold_multiplier: 30
+          enabled: false
+        state: replaced
+
+    # After state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # disable;
+    # management-address 20.2.2.2;
+    # hold-multiplier 30;
+
+    # Using deleted
+    # Before state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 20.2.2.2;
+    # hold-multiplier 30;
+
+    - name: Delete lldp configuration (this will by default remove all lldp configuration)
+      junipernetworks.junos.junos_lldp_global:
+        state: deleted
+
+    # After state:
+    # -------------
+    # user@junos01# # show protocols lldp
+    #
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The configuration as structured data after module completion.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration as structured data prior to module invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;xml 1&#x27;, &#x27;xml 2&#x27;, &#x27;xml 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_lldp_interface.rst
+++ b/docs/junipernetworks.junos.junos_lldp_interface.rst
@@ -1,0 +1,355 @@
+
+.. _junipernetworks.junos.junos_lldp_interface_:
+
+
+*****
+junipernetworks.junos.junos_lldp_interface
+*****
+
+**(deprecated) Manage LLDP interfaces configuration on Juniper JUNOS network devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+DEPRECATED
+----------
+:Removed in Ansible: version: 2.13
+:Why: Updated modules released with more functionality
+:Alternative: Use :ref:`junos_lldp_interfaces <junos_lldp_interfaces_module>` instead.
+
+
+
+Synopsis
+--------
+- This module provides declarative management of LLDP interfaces configuration on Juniper JUNOS network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the interface LLDP should be configured on.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>enabled</li>
+                                                                                                                                                                                                <li>disabled</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Value of <code>present</code> ensures given LLDP configured on given <em>interfaces</em> and is enabled, for value of <code>absent</code> LLDP configuration on given <em>interfaces</em> deleted. Value <code>enabled</code> ensures LLDP protocol is enabled on given <em>interfaces</em> and for value of <code>disabled</code> it ensures LLDP is disabled on given <em>interfaces</em>.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Configure LLDP on specific interfaces
+      junipernetworks.junos.junos_lldp_interface:
+        name: ge-0/0/5
+        state: present
+
+    - name: Disable LLDP on specific interfaces
+      junipernetworks.junos.junos_lldp_interface:
+        name: ge-0/0/5
+        state: disabled
+
+    - name: Enable LLDP on specific interfaces
+      junipernetworks.junos.junos_lldp_interface:
+        name: ge-0/0/5
+        state: enabled
+
+    - name: Delete LLDP configuration on specific interfaces
+      junipernetworks.junos.junos_lldp_interface:
+        name: ge-0/0/5
+        state: present
+
+    - name: Deactivate LLDP on specific interfaces
+      junipernetworks.junos.junos_lldp_interface:
+        name: ge-0/0/5
+        state: present
+        active: false
+
+    - name: Activate LLDP on specific interfaces
+      junipernetworks.junos.junos_lldp_interface:
+        name: ge-0/0/5
+        state: present
+        active: true
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit protocols lldp] +    interface ge-0/0/5;</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+- This  will be removed in version 2.13. *[deprecated]*
+- For more information see `DEPRECATED`_.
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_lldp_interfaces.rst
+++ b/docs/junipernetworks.junos.junos_lldp_interfaces.rst
@@ -1,0 +1,327 @@
+
+.. _junipernetworks.junos.junos_lldp_interfaces_:
+
+
+*****
+junipernetworks.junos.junos_lldp_interfaces
+*****
+
+**LLDP interfaces resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module manages link layer discovery protocol (LLDP) attributes of interfaces on Juniper JUNOS devices.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The list of link layer discovery protocol interface attribute configurations</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enabled</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This is a boolean value to control disabling of LLDP on the interface <code>name</code></div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the interface LLDP needs to be configured on.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state of the configuration after module completion.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using merged
+    # Before state:
+    # -------------
+    # user@junos01# # show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+
+    - name: Merge provided configuration with device configuration
+      junipernetworks.junos.junos_lldp_interfaces:
+        config:
+        - name: ge-0/0/1
+        - name: ge-0/0/2
+          enabled: false
+        state: merged
+
+    # After state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+    # interface ge-0/0/1;
+    # interface ge-0/0/2 {
+    #     disable;
+    # }
+
+    # Using replaced
+    # Before state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+    # interface ge-0/0/1;
+    # interface ge-0/0/2 {
+    #     disable;
+    # }
+
+    - name: Replace provided configuration with device configuration
+      junipernetworks.junos.junos_lldp_interfaces:
+        config:
+        - name: ge-0/0/2
+          disable: false
+        - name: ge-0/0/3
+          enabled: false
+        state: replaced
+
+    # After state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+    # interface ge-0/0/1;
+    # interface ge-0/0/2;
+    # interface ge-0/0/3 {
+    #     disable;
+    # }
+
+    # Using overridden
+    # Before state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+    # interface ge-0/0/1;
+    # interface ge-0/0/2 {
+    #     disable;
+    # }
+
+    - name: Override provided configuration with device configuration
+      junipernetworks.junos.junos_lldp_interfaces:
+        config:
+        - name: ge-0/0/2
+          enabled: false
+        state: overridden
+
+    # After state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+    # interface ge-0/0/2 {
+    #     disable;
+    # }
+
+    # Using deleted
+    # Before state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+    # interface ge-0/0/1;
+    # interface ge-0/0/2;
+    # interface ge-0/0/3 {
+    #     disable;
+    # }
+    - name: Delete lldp interface configuration (this will not delete other lldp configuration)
+      junipernetworks.junos.junos_lldp_interfaces:
+        config:
+        - name: ge-0/0/1
+        - name: ge-0/0/3
+        state: deleted
+
+    # After state:
+    # -------------
+    # user@junos01# show protocols lldp
+    # management-address 10.1.1.1;
+    # advertisement-interval 10000;
+    # interface ge-0/0/2;
+    # interface ge-0/0/1;
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The configuration as structured data after module completion.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration as structured data prior to module invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;xml 1&#x27;, &#x27;xml 2&#x27;, &#x27;xml 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_logging.rst
+++ b/docs/junipernetworks.junos.junos_logging.rst
@@ -1,0 +1,480 @@
+
+.. _junipernetworks.junos.junos_logging_:
+
+
+*****
+junipernetworks.junos.junos_logging
+*****
+
+**Manage logging on network devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides declarative management of logging on Juniper JUNOS devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aggregate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of logging definitions.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>console</li>
+                                                                                                                                                                                                <li>host</li>
+                                                                                                                                                                                                <li>file</li>
+                                                                                                                                                                                                <li>user</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Destination of the logs.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>facility</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Set logging facility.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>files</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Number of files to be archived, this is applicable if value of <em>dest</em> is <code>file</code>. The acceptable value is in range from 1 to 1000.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>level</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Set logging severity levels.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>If value of <code>dest</code> is <em>file</em> it indicates file-name, for <em>user</em> it indicates username and for <em>host</em> indicates the host name to be notified.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rotate_frequency</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Rotate log frequency in minutes, this is applicable if value of <em>dest</em> is <code>file</code>. The acceptable value is in range of 1 to 59. This controls the frequency after which log file is rotated.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>size</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Size of the file in archive, this is applicable if value of <em>dest</em> is <code>file</code>. The acceptable value is in range from 65536 to 1073741824 bytes.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>State of the logging configuration.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: configure console logging
+      junipernetworks.junos.junos_logging:
+        dest: console
+        facility: any
+        level: critical
+
+    - name: remove console logging configuration
+      junipernetworks.junos.junos_logging:
+        dest: console
+        state: absent
+
+    - name: configure file logging
+      junipernetworks.junos.junos_logging:
+        dest: file
+        name: test
+        facility: pfe
+        level: error
+
+    - name: configure logging parameter
+      junipernetworks.junos.junos_logging:
+        files: 30
+        size: 65536
+        rotate_frequency: 10
+
+    - name: Configure file logging using aggregate
+      junipernetworks.junos.junos_logging:
+        dest: file
+        aggregate:
+        - name: test-1
+          facility: pfe
+          level: critical
+        - name: test-2
+          facility: kernel
+          level: emergency
+        active: true
+
+    - name: Delete file logging using aggregate
+      junipernetworks.junos.junos_logging:
+        aggregate:
+        - {dest: file, name: test-1, facility: pfe, level: critical}
+        - {dest: file, name: test-2, facility: kernel, level: emergency}
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit system syslog] +    [edit system syslog]
+         file interactive-commands { ... }
+    +    file test { +        pfe critical; +    }</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_netconf.rst
+++ b/docs/junipernetworks.junos.junos_netconf.rst
@@ -1,0 +1,294 @@
+
+.. _junipernetworks.junos.junos_netconf_:
+
+
+*****
+junipernetworks.junos.junos_netconf
+*****
+
+**Configures the Junos Netconf system service**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides an abstraction that enables and configures the netconf system service running on Junos devices.  This module can be used to easily enable the Netconf API. Netconf provides a programmatic interface for working with configuration and state resources as defined in RFC 6242. If the ``netconf_port`` is not mentioned in the task by default netconf will be enabled on port 830 only.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>netconf_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">830</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>This argument specifies the port the netconf service should listen on for SSH connections.  The default port as defined in RFC 6242 is 830.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: listens_on</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the state of the <code>junos_netconf</code> resource on the remote device.  If the <em>state</em> argument is set to <em>present</em> the netconf service will be configured.  If the <em>state</em> argument is set to <em>absent</em> the netconf service will be removed from the configuration.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``network_cli``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - If ``netconf_port`` value is not mentioned in task by default it will be enabled on port 830 only. Although ``netconf_port`` value can be from 1 through 65535, avoid configuring access on a port that is normally assigned for another service. This practice avoids potential resource conflicts.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: enable netconf service on port 830
+      junipernetworks.junos.junos_netconf:
+        listens_on: 830
+        state: present
+
+    - name: disable netconf service
+      junipernetworks.junos.junos_netconf:
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when changed is True</td>
+                <td>
+                                                                        <div>Returns the command sent to the remote device</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">set system services netconf ssh port 830</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Peter Sprygada (@privateip)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_ospf.rst
+++ b/docs/junipernetworks.junos.junos_ospf.rst
@@ -1,0 +1,965 @@
+
+.. _junipernetworks.junos.junos_ospf_:
+
+
+*****
+junipernetworks.junos.junos_ospf
+*****
+
+**OSPF resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module manages global OSPFv2 configuration on devices running Juniper JUNOS.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+- xmltodict (>=0.12.0)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="5">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="5">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A list of OSPF process configuration.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>areas</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A list of OSPF areas&#x27; configuration.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>area_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The Area ID as an integer or IP Address.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>area_range</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure an address range for the area.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>interfaces</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of interfaces in this area.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>authentication</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Type of authentication to use.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>bandwidth_based_metrics</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>bandwidth</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>1g</li>
+                                                                                                                                                                                                <li>10g</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>BW to apply metric to.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>metric</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>None</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>flood_reduction</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Enable flood reduction.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>metric</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Metric applied to the interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>passive</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>priority</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Priority for the interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dead_interval</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Dead interval (seconds).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hello_interval</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Hello interval (seconds).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>poll_interval</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Poll interval (seconds).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>retransmit_interval</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Retransmit interval (seconds).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>transit_delay</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Transit delay (seconds).</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>stub</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Settings for configuring the area as a stub.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>default_metric</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Metric for the default route in this area.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>set</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure the area as a stub.</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>external_preference</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Preference of external routes.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>overload</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Time after which overload mode is reset (seconds).</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>preference</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Preference of internal routes.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>prefix_export_limit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Maximum number of external prefixes that can be exported.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>reference_bandwidth</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>1g</li>
+                                                                                                                                                                                                <li>10g</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Bandwidth for calculating metric defaults.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rfc1583compatibility</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Set RFC1583 compatibility</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>router_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The OSPF router id.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>spf_options</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure options for SPF.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>delay</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Time to wait before running an SPF (seconds).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>holddown</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Time to hold down before running an SPF (seconds).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rapid_runs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Number of maximum rapid SPF runs before holddown (seconds).</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                                <td colspan="5">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                                                                                                                                <li>gathered</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state the configuration should be left in.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the device being managed.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - Tested against JunOS v18.4R1
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using merged
+    #
+    # Before state
+    # ------------
+    #
+    # admin# show protocols ospf
+
+    - name: Merge Junos OSPF config
+      junipernetworks.junos.junos_ospf:
+        config:
+        - router_id: 10.200.16.75
+          reference_bandwidth: 10g
+          areas:
+          - area_id: 0.0.0.100
+            area_range: 10.200.16.0/24
+            stub:
+              default_metric: 100
+              set: true
+            interfaces:
+            - name: so-0/0/0.0
+              priority: 3
+              metric: 5
+              flood_reduction: false
+              passive: true
+              bandwidth_based_metrics:
+              - bandwidth: 1g
+                metric: 5
+              - bandwidth: 10g
+                metric: 40
+              timers:
+                dead_interval: 4
+                hello_interval: 2
+                poll_interval: 2
+                retransmit_interval: 2
+          rfc1583compatibility: false
+        state: merged
+
+    # After state
+    # -----------
+    #
+    # admin# show protocols ospf
+    # reference-bandwidth 10g;
+    # no-rfc-1583;
+    # area 0.0.0.100 {
+    #     stub default-metric 100;
+    #     area-range 10.200.16.0/24;
+    #     interface so-0/0/0.0 {
+    #         passive;
+    #         bandwidth-based-metrics {
+    #             bandwidth 1g metric 5;
+    #             bandwidth 10g metric 40;
+    #         }
+    #         metric 5;
+    #         priority 3;
+    #         retransmit-interval 2;
+    #         hello-interval 2;
+    #         dead-interval 4;
+    #         poll-interval 2;
+    #     }
+    # }
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">-</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The resulting configuration model invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">-</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration prior to the model invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;command 1&#x27;, &#x27;command 2&#x27;, &#x27;command 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Daniel Mellado (@dmellado)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_package.rst
+++ b/docs/junipernetworks.junos.junos_package.rst
@@ -1,0 +1,432 @@
+
+.. _junipernetworks.junos.junos_package_:
+
+
+*****
+junipernetworks.junos.junos_package
+*****
+
+**Installs packages on remote devices running Junos**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can install new and updated packages on remote devices running Junos.  The module will compare the specified package with the one running on the remote device and install the specified version if there is a mismatch
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- junos-eznc
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>force</em> argument instructs the module to bypass the package version check and install the packaged identified in <em>src</em> on the remote device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>force_host</em> argument controls the way software package or bundle is added on remote JUNOS host and is applicable for JUNOS QFX5100 device. If the value is set to <code>True</code> it will ignore any warnings while adding the host software package or bundle.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>issu</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>issu</em> argument is a boolean flag when set to <code>True</code> allows unified in-service software upgrade (ISSU) feature which enables you to upgrade between two different Junos OS releases with no disruption on the control plane and with minimal disruption of traffic.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>no_copy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>no_copy</em> argument is responsible for instructing the remote device on where to install the package from.  When enabled, the package is transferred to the remote device prior to installing.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>reboot</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>In order for a package to take effect, the remote device must be restarted.  When enabled, this argument will instruct the module to reboot the device once the updated package has been installed. If disabled or the remote package does not need to be changed, the device will not be started.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>src</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>src</em> argument specifies the path to the source package to be installed on the remote device in the advent of a version mismatch. The <em>src</em> argument can be either a localized path or a full path to the package file to install.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: package</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>ssh_config</code> argument is path to the SSH configuration file. This can be used to load SSH information from a configuration file. If this option is not given by default ~/.ssh/config is queried.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_private_key_file</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>ssh_private_key_file</code> argument is path to the SSH private key file. This can be used if you need to provide a private key rather than loading the key into the ssh-key-ring/environment</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>validate</em> argument is responsible for instructing the remote device to skip checking the current device configuration compatibility with the package being installed. When set to false validation is not performed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>version</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <em>version</em> argument can be used to explicitly specify the version of the package that should be installed on the remote device.  If the <em>version</em> argument is not specified, then the version is extracts from the <em>src</em> filename.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Works with ``local`` connections only.
+   - Since this module uses junos-eznc to establish connection with junos device the netconf configuration parameters needs to be passed using module options for example ``ssh_config`` unlike other junos modules that uses ``netconf`` connection type.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # the required set of connection arguments have been purposely left off
+    # the examples for brevity
+
+    - name: install local package on remote device
+      junipernetworks.junos.junos_package:
+        src: junos-vsrx-12.1X46-D10.2-domestic.tgz
+
+    - name: install local package on remote device without rebooting
+      junipernetworks.junos.junos_package:
+        src: junos-vsrx-12.1X46-D10.2-domestic.tgz
+        reboot: no
+
+    - name: install local package on remote device with jumpost
+      junipernetworks.junos.junos_package:
+        src: junos-vsrx-12.1X46-D10.2-domestic.tgz
+        ssh_config: /home/user/customsshconfig
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Peter Sprygada (@privateip)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_ping.rst
+++ b/docs/junipernetworks.junos.junos_ping.rst
@@ -1,0 +1,481 @@
+
+.. _junipernetworks.junos.junos_ping_:
+
+
+*****
+junipernetworks.junos.junos_ping
+*****
+
+**Tests reachability using ping from devices running Juniper JUNOS**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Tests reachability using ping from devices running Juniper JUNOS to a remote destination.
+- Tested against Junos (17.3R1.10)
+- For a general purpose network module, see the :ref:`net_ping <net_ping_module>` module.
+- For Windows targets, use the :ref:`win_ping <win_ping_module>` module instead.
+- For targets running Python, use the :ref:`ping <ping_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>count</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">5</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Number of packets to send to check reachability.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The IP Address or hostname (resolvable by the device) of the remote node.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>interface</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The source interface to use while sending the ping packet(s).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>interval</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Determines the interval (in seconds) between consecutive pings.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>size</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Determines the size (in bytes) of the ping packet(s).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>source</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The IP Address to use while sending the ping packet(s).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Determines if the expected result is success or fail.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ttl</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The time-to-live value for the ICMP packet(s).</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - For a general purpose network module, see the :ref:`net_ping <net_ping_module>` module.
+   - For Windows targets, use the :ref:`win_ping <win_ping_module>` module instead.
+   - For targets running Python, use the :ref:`ping <ping_module>` module instead.
+   - This module works only with connection ``network_cli``.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Test reachability to 10.10.10.10
+      junipernetworks.junos.junos_ping:
+        dest: 10.10.10.10
+
+    - name: Test reachability to 10.20.20.20 using source and size set
+      junipernetworks.junos.junos_ping:
+        dest: 10.20.20.20
+        size: 1024
+        ttl: 128
+
+    - name: Test unreachability to 10.30.30.30 using interval
+      junipernetworks.junos.junos_ping:
+        dest: 10.30.30.30
+        interval: 3
+        state: absent
+
+    - name: Test reachability to 10.40.40.40 setting count and interface
+      junipernetworks.junos.junos_ping:
+        dest: 10.40.40.40
+        interface: fxp0
+        count: 20
+        size: 512
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>List of commands sent.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;ping 10.8.38.44 count 10 source 10.8.38.38 ttl 128&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>packet_loss</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Percentage of packets lost.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">0%</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>packets_rx</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Packets successfully received.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">20</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>packets_tx</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Packets successfully transmitted.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">20</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>rtt</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>when ping succeeds</td>
+                <td>
+                                                                        <div>The round trip time (RTT) stats.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;avg&#x27;: 2, &#x27;max&#x27;: 8, &#x27;min&#x27;: 1, &#x27;stddev&#x27;: 24}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Nilashish Chakraborty (@NilashishC)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_rpc.rst
+++ b/docs/junipernetworks.junos.junos_rpc.rst
@@ -1,0 +1,366 @@
+
+.. _junipernetworks.junos.junos_rpc_:
+
+
+*****
+junipernetworks.junos.junos_rpc
+*****
+
+**Runs an arbitrary RPC over NetConf on an Juniper JUNOS device**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Sends a request to the remote device running JUNOS to execute the specified RPC using the NetConf transport.  The reply is then returned to the playbook in the ``xml`` key.  If an alternate output format is requested, the reply is transformed to the requested output.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>args</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>args</code> argument provides a set of arguments for the RPC call and are encoded in the request message.  This argument accepts a set of key=value arguments.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>attrs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>attrs</code> arguments defines a list of attributes and their values to set for the RPC call. This accepts a dictionary of key-values.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>output</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"xml"</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>output</code> argument specifies the desired output of the return data.  This argument accepts one of <code>xml</code>, <code>text</code>, or <code>json</code>.  For <code>json</code>, the JUNOS device must be running a version of software that supports native JSON output.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rpc</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>rpc</code> argument specifies the RPC call to send to the remote devices to be executed.  The RPC Reply message is parsed and the contents are returned to the playbook.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: collect interface information using rpc
+      junipernetworks.junos.junos_rpc:
+        rpc: get-interface-information
+        args:
+          interface-name: em0
+          media: true
+
+    - name: get system information
+      junipernetworks.junos.junos_rpc:
+        rpc: get-system-information
+
+    - name: load configuration
+      junipernetworks.junos.junos_rpc:
+        rpc: load-configuration
+        attrs:
+          action: override
+          url: /tmp/config.conf
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>output</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The rpc rely converted to the output format.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>output_lines</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The text output split into lines for readability.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>xml</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The xml return string from the rpc request.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Peter Sprygada (@privateip)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_scp.rst
+++ b/docs/junipernetworks.junos.junos_scp.rst
@@ -1,0 +1,383 @@
+
+.. _junipernetworks.junos.junos_scp_:
+
+
+*****
+junipernetworks.junos.junos_scp
+*****
+
+**Transfer files from or to remote devices running Junos**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module transfers files via SCP from or to remote devices running Junos.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- junos-eznc
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"."</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>dest</code> argument specifies the path in which to receive the files.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>recursive</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>recursive</code> argument enables recursive transfer of files and directories.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>remote_src</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>remote_src</code> argument enables the download of files (<em>scp get</em>) from the remote device. The default behavior is to upload files (<em>scp put</em>) to the remote device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>src</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>src</code> argument takes a single path, or a list of paths to be transferred. The argument <code>recursive</code> must be <code>true</code> to transfer directories.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>ssh_config</code> argument is path to the SSH configuration file. This can be used to load SSH information from a configuration file. If this option is not given by default ~/.ssh/config is queried.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_private_key_file</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>ssh_private_key_file</code> argument is path to the SSH private key file. This can be used if you need to provide a private key rather than loading the key into the ssh-key-ring/environment</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vMX JUNOS version 17.3R1.10.
+   - Works with ``local`` connections only.
+   - Since this module uses junos-eznc to establish connection with junos device the netconf configuration parameters needs to be passed using module options for example ``ssh_config`` unlike other junos modules that uses ``netconf`` connection type.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # the required set of connection arguments have been purposely left off
+    # the examples for brevity
+    - name: upload local file to home directory on remote device
+      junipernetworks.junos.junos_scp:
+        src: test.tgz
+
+    - name: upload local file to tmp directory on remote device
+      junipernetworks.junos.junos_scp:
+        src: test.tgz
+        dest: /tmp/
+
+    - name: download file from remote device
+      junipernetworks.junos.junos_scp:
+        src: test.tgz
+        remote_src: true
+
+    - name: ssh config file path for jumphost config
+      junipernetworks.junos.junos_scp:
+        src: test.tgz
+        remote_src: true
+        ssh_config: /home/user/customsshconfig
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>changed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>always true</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Christian Giese (@GIC-de)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_static_route.rst
+++ b/docs/junipernetworks.junos.junos_static_route.rst
@@ -1,0 +1,463 @@
+
+.. _junipernetworks.junos.junos_static_route_:
+
+
+*****
+junipernetworks.junos.junos_static_route
+*****
+
+**(deprecated) Manage static IP routes on Juniper JUNOS network devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+DEPRECATED
+----------
+:Removed in Ansible: version: 2.13
+:Why: Updated modules released with more functionality
+:Alternative: Use :ref:`junos_static_routes <junos_static_routes_module>` instead.
+
+
+
+Synopsis
+--------
+- This module provides declarative management of static IP routes on Juniper JUNOS network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>address</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Network address with prefix of the static route.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: prefix</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aggregate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of static route definitions</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>next_hop</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Next hop IP of the static route.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>preference</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Global admin preference of the static route.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: admin_distance</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>qualified_next_hop</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Qualified next hop IP of the static route. Qualified next hops allow to associate preference with a particular next-hop address.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>qualified_preference</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Assign preference for qualified next hop.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>State of the static route configuration.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: configure static route
+      junipernetworks.junos.junos_static_route:
+        address: 192.168.2.0/24
+        next_hop: 10.0.0.1
+        preference: 10
+        qualified_next_hop: 10.0.0.2
+        qualified_preference: 3
+        state: present
+
+    - name: delete static route
+      junipernetworks.junos.junos_static_route:
+        address: 192.168.2.0/24
+        state: absent
+
+    - name: deactivate static route configuration
+      junipernetworks.junos.junos_static_route:
+        address: 192.168.2.0/24
+        next_hop: 10.0.0.1
+        preference: 10
+        qualified_next_hop: 10.0.0.2
+        qualified_preference: 3
+        state: present
+        active: false
+
+    - name: activate static route configuration
+      junipernetworks.junos.junos_static_route:
+        address: 192.168.2.0/24
+        next_hop: 10.0.0.1
+        preference: 10
+        qualified_next_hop: 10.0.0.2
+        qualified_preference: 3
+        state: present
+        active: true
+
+    - name: Configure static route using aggregate
+      junipernetworks.junos.junos_static_route:
+        aggregate:
+        - {address: 4.4.4.0/24, next_hop: 3.3.3.3, qualified_next_hop: 5.5.5.5, qualified_preference: 30}
+        - {address: 5.5.5.0/24, next_hop: 6.6.6.6, qualified_next_hop: 7.7.7.7, qualified_preference: 12}
+        preference: 10
+
+    - name: Delete static route using aggregate
+      junipernetworks.junos.junos_static_route:
+        aggregate:
+        - address: 4.4.4.0/24
+        - address: 5.5.5.0/24
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit routing-options static]
+         route 2.2.2.0/24 { ... }
+    +    route 4.4.4.0/24 {
+            next-hop 3.3.3.3;
+            qualified-next-hop 5.5.5.5 {
+    +            preference 30;
+             }
+    +        preference 10; +    }</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+- This  will be removed in version 2.13. *[deprecated]*
+- For more information see `DEPRECATED`_.
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_static_routes.rst
+++ b/docs/junipernetworks.junos.junos_static_routes.rst
@@ -1,0 +1,485 @@
+
+.. _junipernetworks.junos.junos_static_routes_:
+
+
+*****
+junipernetworks.junos.junos_static_routes
+*****
+
+**Static routes resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides declarative management of static routes on Juniper JUNOS devices
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+- xmltodict (>=0.12)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="5">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="5">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A dictionary of static routes options</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>address_families</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Address family to use for the static routes</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>afi</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>ipv4</li>
+                                                                                                                                                                                                <li>ipv6</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>afi to use for the static routes</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>routes</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Static route configuration</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Static route destination including prefix</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>metric</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Metric value for the static route</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>next_hop</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Next hop to destination</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>forward_router_address</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of next hops</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vrf</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Virtual Routing and Forwarding (VRF) name</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="5">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state the configuration should be left in</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the device being managed.
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - Tested against JunOS v18.4R1
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using deleted
+
+    # Before state
+    # ------------
+    #
+    # admin# show routing-options
+    # static {
+    #     route 192.168.47.0/24 next-hop 172.16.1.2;
+    #     route 192.168.16.0/24 next-hop 172.16.1.2;
+    #     route 10.200.16.75/24 next-hop 10.200.16.2;
+    # }
+
+    - name: Delete provided configuration (default operation is merge)
+      junipernetworks.junos.junos_static_routes:
+        config:
+        - address_families:
+          - afi: ipv4
+            routes:
+            - dest: 10.200.16.75/24
+              next_hop:
+              - forward_router_address: 10.200.16.2
+        state: deleted
+
+    # After state:
+    # ------------
+    #
+    # admin# show routing-options
+    # static {
+    #     route 192.168.47.0/24 next-hop 172.16.1.2;
+    #     route 192.168.16.0/24 next-hop 172.16.1.2;
+    # }
+
+    # Using merged
+
+    # Before state
+    # ------------
+    #
+    # admin# show routing-options
+    # static {
+    #     route 192.168.47.0/24 next-hop 172.16.1.2;
+    #     route 192.168.16.0/24 next-hop 172.16.1.2;
+    # }
+
+    - name: Merge provided configuration with device configuration (default operation
+        is merge)
+      junipernetworks.junos.junos_static_routes:
+        config:
+        - address_families:
+          - afi: ipv4
+            routes:
+            - dest: 10.200.16.75/24
+              next_hop:
+              - forward_router_address: 10.200.16.2
+        state: merged
+
+    # After state:
+    # ------------
+    #
+    # admin# show routing-options
+    # static {
+    #     route 192.168.47.0/24 next-hop 172.16.1.2;
+    #     route 192.168.16.0/24 next-hop 172.16.1.2;
+    #     route 10.200.16.75/24 next-hop 10.200.16.2;
+    # }
+
+    # Using overridden
+
+    # Before state
+    # ------------
+    #
+    # admin# show routing-options
+    # static {
+    #     route 192.168.47.0/24 next-hop 172.16.1.2;
+    #     route 192.168.16.0/24 next-hop 172.16.0.1;
+    # }
+
+    - name: Override provided configuration with device configuration (default operation
+        is merge)
+      junipernetworks.junos.junos_static_routes:
+        config:
+        - address_families:
+          - afi: ipv4
+            routes:
+            - dest: 10.200.16.75/24
+              next_hop:
+              - forward_router_address: 10.200.16.2
+        state: overridden
+
+    # After state:
+    # ------------
+    #
+    # admin# show routing-options
+    # static {
+    #     route 10.200.16.75/24 next-hop 10.200.16.2;
+    # }
+
+    # Using replaced
+
+    # Before state
+    # ------------
+    #
+    # admin# show routing-options
+    # static {
+    #     route 192.168.47.0/24 next-hop 172.16.1.2;
+    #     route 192.168.16.0/24 next-hop 172.16.1.2;
+    # }
+
+    - name: Replace provided configuration with device configuration (default operation
+        is merge)
+      junipernetworks.junos.junos_static_routes:
+        config:
+        - address_families:
+          - afi: ipv4
+            routes:
+            - dest: 192.168.47.0/24
+              next_hop:
+              - forward_router_address: 10.200.16.2
+        state: replaced
+
+    # After state:
+    # ------------
+    #
+    # admin# show routing-options
+    # static {
+    #     route 192.168.47.0/24 next-hop 10.200.16.2;
+    #     route 192.168.16.0/24 next-hop 172.16.1.2;
+    # }
+
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The resulting configuration model invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration prior to the model invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;command 1&#x27;, &#x27;command 2&#x27;, &#x27;command 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Daniel Mellado (@dmellado)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_system.rst
+++ b/docs/junipernetworks.junos.junos_system.rst
@@ -1,0 +1,382 @@
+
+.. _junipernetworks.junos.junos_system_:
+
+
+*****
+junipernetworks.junos.junos_system
+*****
+
+**Manage the system attributes on Juniper JUNOS devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides declarative management of node system attributes on Juniper JUNOS devices.  It provides an option to configure host system parameters or remove those parameters from the device active configuration.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure the IP domain name on the remote device to the provided value. Value should be in the dotted name form and will be appended to the <code>hostname</code> to create a fully-qualified domain name.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_search</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Provides the list of domain suffixes to append to the hostname for the purpose of doing name resolution. This argument accepts a list of names and will be reconciled with the current active configuration on the running node.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configure the device hostname parameter. This option takes an ASCII string value.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name_servers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of DNS name servers by IP address to use to perform name resolution lookups.  This argument accepts either a list of DNS servers See examples.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>State of the configuration values in the device&#x27;s current active configuration.  When set to <em>present</em>, the values should be configured in the device active configuration and when set to <em>absent</em> the values should not be in the device active configuration</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: configure hostname and domain name
+      junipernetworks.junos.junos_system:
+        hostname: junos01
+        domain_name: test.example.com
+        domain-search:
+        - ansible.com
+        - redhat.com
+        - juniper.net
+
+    - name: remove configuration
+      junipernetworks.junos.junos_system:
+        state: absent
+
+    - name: configure name servers
+      junipernetworks.junos.junos_system:
+        name_servers:
+        - 8.8.8.8
+        - 8.8.4.4
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit system] +  host-name test; +  domain-name ansible.com; +  domain-search redhat.com; [edit system name-server]
+        172.26.1.1 { ... }
+    +   8.8.8.8;</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_user.rst
+++ b/docs/junipernetworks.junos.junos_user.rst
@@ -1,0 +1,460 @@
+
+.. _junipernetworks.junos.junos_user_:
+
+
+*****
+junipernetworks.junos.junos_user
+*****
+
+**Manage local user accounts on Juniper JUNOS devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module manages locally configured user accounts on remote network devices running the JUNOS operating system.  It provides a set of arguments for creating, removing and updating locally defined accounts
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aggregate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>aggregate</code> argument defines a list of users to be configured on the remote device.  The list of users will be compared against the current users and only changes will be added or removed from the device configuration.  This argument is mutually exclusive with the name argument.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: users, collection</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>encrypted_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>encrypted_password</code> argument set already hashed password for the user account on the remote system.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>full_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>full_name</code> argument provides the full name of the user account to be created on the remote device.  This argument accepts any text string value.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>name</code> argument defines the username of the user to be created on the system.  This argument must follow appropriate usernaming conventions for the target device running JUNOS.  This argument is mutually exclusive with the <code>aggregate</code> argument.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>purge</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>purge</code> argument instructs the module to consider the users definition absolute.  It will remove any previously configured users on the device with the exception of the current defined set of aggregate.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>role</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>operator</li>
+                                                                                                                                                                                                <li>read-only</li>
+                                                                                                                                                                                                <li>super-user</li>
+                                                                                                                                                                                                <li>unauthorized</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>role</code> argument defines the role of the user account on the remote system.  User accounts can have more than one role configured.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sshkey</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>sshkey</code> argument defines the public SSH key to be configured for the user account on the remote system.  This argument must be a valid SSH key</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The <code>state</code> argument configures the state of the user definitions as it relates to the device operational configuration.  When set to <em>present</em>, the user should be configured in the device active configuration and when set to <em>absent</em> the user should not be in the device active configuration</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: create new user account
+      junipernetworks.junos.junos_user:
+        name: ansible
+        role: super-user
+        sshkey: "{{ lookup('file', '~/.ssh/ansible.pub') }}"
+        state: present
+
+    - name: remove a user account
+      junipernetworks.junos.junos_user:
+        name: ansible
+        state: absent
+
+    - name: remove all user accounts except ansible
+      junipernetworks.junos.junos_user:
+        aggregate:
+        - name: ansible
+        purge: yes
+
+    - name: set user password
+      junipernetworks.junos.junos_user:
+        name: ansible
+        role: super-user
+        encrypted_password: "{{ 'my-password' | password_hash('sha512') }}"
+        state: present
+
+    - name: Create list of users
+      junipernetworks.junos.junos_user:
+        aggregate:
+        - {name: test_user1, full_name: test_user2, role: operator, state: present}
+        - {name: test_user2, full_name: test_user2, role: read-only, state: present}
+
+    - name: Delete list of users
+      junipernetworks.junos.junos_user:
+        aggregate:
+        - {name: test_user1, full_name: test_user2, role: operator, state: absent}
+        - {name: test_user2, full_name: test_user2, role: read-only, state: absent}
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit system login] +    user test-user { +        uid 2005; +        class read-only; +    }</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Peter Sprygada (@privateip)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_vlan.rst
+++ b/docs/junipernetworks.junos.junos_vlan.rst
@@ -1,0 +1,481 @@
+
+.. _junipernetworks.junos.junos_vlan_:
+
+
+*****
+junipernetworks.junos.junos_vlan
+*****
+
+**(deprecated) Manage VLANs on Juniper JUNOS network devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+DEPRECATED
+----------
+:Removed in Ansible: version: 2.13
+:Why: Updated modules released with more functionality
+:Alternative: Use :ref:`junos_vlans <junos_vlans_module>` instead.
+
+
+
+Synopsis
+--------
+- This module provides declarative management of VLANs on Juniper JUNOS network devices.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aggregate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of VLANs definitions.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Text description of VLANs.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filter_input</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The name of input filter.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filter_output</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The name of output filter.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>interfaces</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>List of interfaces to check the VLAN has been configured correctly.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>l3_interface</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of logical layer 3 interface.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of the VLAN.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>State of the VLAN configuration.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vlan_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>ID of the VLAN. Range 1-4094.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: configure VLAN ID and name
+      junipernetworks.junos.junos_vlan:
+        name: test
+        vlan_id: 20
+
+    - name: Link to logical layer 3 interface
+      junipernetworks.junos.junos_vlan:
+        name: test
+        vlan_id: 20
+        l3-interface: vlan.20
+
+    - name: remove VLAN configuration
+      junipernetworks.junos.junos_vlan:
+        name: test
+        state: absent
+
+    - name: deactive VLAN configuration
+      junipernetworks.junos.junos_vlan:
+        name: test
+        state: present
+        active: false
+
+    - name: activate VLAN configuration
+      junipernetworks.junos.junos_vlan:
+        name: test
+        state: present
+        active: true
+
+    - name: Create vlan configuration using aggregate
+      junipernetworks.junos.junos_vlan:
+        aggregate:
+        - {vlan_id: 159, name: test_vlan_1, description: test vlan-1}
+        - {vlan_id: 160, name: test_vlan_2, description: test vlan-2}
+
+    - name: Delete vlan configuration using aggregate
+      junipernetworks.junos.junos_vlan:
+        aggregate:
+        - {vlan_id: 159, name: test_vlan_1}
+        - {vlan_id: 160, name: test_vlan_2}
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit vlans] +   test-vlan-1 { +       vlan-id 60; +   }</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+- This  will be removed in version 2.13. *[deprecated]*
+- For more information see `DEPRECATED`_.
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_vlans.rst
+++ b/docs/junipernetworks.junos.junos_vlans.rst
@@ -1,0 +1,288 @@
+
+.. _junipernetworks.junos.junos_vlans_:
+
+
+*****
+junipernetworks.junos.junos_vlans
+*****
+
+**VLANs resource module**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module creates and manages VLAN configurations on Junos OS.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.6.4)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>A dictionary of Vlan options</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Text description of VLANs</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Name of VLAN.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vlan_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>IEEE 802.1q VLAN identifier for VLAN (1..4094).</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>replaced</li>
+                                                                                                                                                                                                <li>overridden</li>
+                                                                                                                                                                                                <li>deleted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The state of the configuration after module completion.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed
+   - Tested against Junos OS 18.4R1
+   - This module works with connection ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Using merged
+    #############
+
+    # Before State
+    # ------------
+    #
+    # admin# show vlans
+    # vlan-2 {
+    #     vlan-id 2;
+    # }
+    # vlan-3 {
+    #     vlan-id 3;
+    # }
+
+    - name: Merge JUNOS vlan
+      junipernetworks.junos.junos_vlans:
+        config:
+        - name: vlan-1
+          vlan-id: 1
+      state: merged
+    - name: Replace JUNOS vlan
+      junipernetworks.junos.junos_vlans:
+        config:
+        - name: vlan-1
+          vlan-id: 10
+        - name: vlan-3
+          vlan-id: 30
+      state: replaced
+    - name: Override JUNOS vlan
+      junipernetworks.junos.junos_vlans:
+        config:
+        - name: vlan-4
+          vlan-id: 100
+        - name: vlan-2
+          vlan-id: 200
+      state: overridden
+    - name: Delete JUNOS vlan
+      junipernetworks.junos.junos_vlans:
+        config:
+        - name: vlan-1
+      state: deleted
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>after</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when changed</td>
+                <td>
+                                                                        <div>The configuration as structured data after module completion.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The configuration as structured data prior to module invocation.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format
+     of the parameters above.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>commands</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The set of commands pushed to the remote device.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;xml 1&#x27;, &#x27;xml 2&#x27;, &#x27;xml 3&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Daniel Mellado (@danielmellado)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/junipernetworks.junos.junos_vrf.rst
+++ b/docs/junipernetworks.junos.junos_vrf.rst
@@ -1,0 +1,478 @@
+
+.. _junipernetworks.junos.junos_vrf_:
+
+
+*****
+junipernetworks.junos.junos_vrf
+*****
+
+**Manage the VRF definitions on Juniper JUNOS devices**
+
+
+Version added: 1.0.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides declarative management of VRF definitions on Juniper JUNOS devices.  It allows playbooks to manage individual or the entire VRF collection.
+
+
+
+Requirements
+------------
+The below requirements are needed on the local master node that executes this .
+
+- ncclient (>=v0.5.2)
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                            <th>Configuration</th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>active</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies whether or not the configuration is active or deactivated</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>aggregate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The set of VRF definition objects to be configured on the remote JUNOS device.  Ths list entries can either be the VRF name or a hash of VRF definitions and attributes.  This argument is mutually exclusive with the <code>name</code> argument.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Provides a short description of the VRF definition in the current active configuration.  The VRF definition value accepts alphanumeric characters used to provide additional information about the VRF.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>interfaces</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Identifies the set of interfaces that should be configured in the VRF. Interfaces must be routed interfaces in order to be placed into a VRF.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The name of the VRF definition to be managed on the remote IOS device.  The VRF definition name is an ASCII string name used to uniquely identify the VRF.  This argument is mutually exclusive with the <code>aggregate</code> argument</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div><b>Deprecated</b></div>
+                                            <div>Starting with Ansible 2.5 we recommend using <code>connection: network_cli</code> or <code>connection: netconf</code>.</div>
+                                            <div>For more information please see the <a href='../network/user_guide/platform_junos.html'>Junos OS Platform Options guide</a>.</div>
+                                            <div><hr/></div>
+                                            <div>A dict object containing connection details.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the DNS host name or address for connecting to the remote device over the specified transport.  The value of host is used as the destination address for the transport.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the password to use to authenticate the connection to the remote device.   This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_PASSWORD</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">22</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the port to use when building the connection to the remote device.  The port value will default to the well known SSH port of 22 (for <code>transport=cli</code>) or port 830 (for <code>transport=netconf</code>) device.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ssh_keyfile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the SSH key to use to authenticate the connection to the remote device.   This value is the path to the key used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_SSH_KEYFILE</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10</div>
+                                    </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Specifies the timeout in seconds for communicating with the network device for either connecting or sending commands.  If the timeout is exceeded before the operation is completed, the module will error.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the username to use to authenticate the connection to the remote device.  This value is used to authenticate the SSH session. If the value is not specified in the task, the value of environment variable <code>ANSIBLE_NET_USERNAME</code> will be used instead.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rd</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>The router-distinguisher value uniquely identifies the VRF to routing processes on the remote IOS system.  The RD value takes the form of <code>A:B</code> where <code>A</code> and <code>B</code> are both numeric values.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Configures the state of the VRF definition as it relates to the device operational configuration.  When set to <em>present</em>, the VRF should be configured in the device active configuration and when set to <em>absent</em> the VRF should not be in the device active configuration</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>table_label</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>Causes JUNOS to allocate a VPN label per VRF rather than per VPN FEC. This allows for forwarding of traffic to directly connected subnets, COS Egress filtering etc.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>target</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                    <td>
+                                                                                            </td>
+                                                <td>
+                                            <div>It configures VRF target community configuration. The target value takes the form of <code>target:A:B</code> where <code>A</code> and <code>B</code> are both numeric values.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the netconf system service be enabled on the remote device being managed.
+   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
+   - Recommended connection is ``netconf``. See `the Junos OS Platform Options <../network/user_guide/platform_junos.html>`_.
+   - This module also works with ``local`` connections for legacy playbooks.
+   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
+   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+   - For more information on using Ansible to manage Juniper network devices see https://www.ansible.com/ansible-juniper.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Configure vrf configuration
+      junipernetworks.junos.junos_vrf:
+        name: test-1
+        description: test-vrf-1
+        interfaces:
+        - ge-0/0/3
+        - ge-0/0/2
+        rd: 192.0.2.1:10
+        target: target:65514:113
+        state: present
+
+    - name: Remove vrf configuration
+      junipernetworks.junos.junos_vrf:
+        name: test-1
+        description: test-vrf-1
+        interfaces:
+        - ge-0/0/3
+        - ge-0/0/2
+        rd: 192.0.2.1:10
+        target: target:65514:113
+        state: absent
+
+    - name: Deactivate vrf configuration
+      junipernetworks.junos.junos_vrf:
+        name: test-1
+        description: test-vrf-1
+        interfaces:
+        - ge-0/0/3
+        - ge-0/0/2
+        rd: 192.0.2.1:10
+        target: target:65514:113
+        active: false
+
+    - name: Activate vrf configuration
+      junipernetworks.junos.junos_vrf:
+        name: test-1
+        description: test-vrf-1
+        interfaces:
+        - ge-0/0/3
+        - ge-0/0/2
+        rd: 192.0.2.1:10
+        target: target:65514:113
+        active: true
+
+    - name: Create vrf using aggregate
+      junipernetworks.junos.junos_vrf:
+        aggregate:
+        - name: test-1
+          description: test-vrf-1
+          interfaces:
+          - ge-0/0/3 - ge-0/0/2
+          rd: 192.0.2.1:10
+          target: target:65514:113
+        - name: test-2
+          description: test-vrf-2
+          interfaces:
+          - ge-0/0/4
+          - ge-0/0/5
+          rd: 192.0.2.2:10
+          target: target:65515:114
+      state: present
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this :
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>diff.prepared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>when configuration is changed and diff option is enabled.</td>
+                <td>
+                                                                        <div>Configuration difference before and after applying change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[edit routing-instances] +   test-1 { +       description test-vrf-1; +       instance-type vrf; +       interface ge-0/0/2.0; +       interface ge-0/0/3.0; +       route-distinguisher 192.0.2.1:10; +       vrf-target target:65514:113; +   }</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ganesh Nalawade (@ganeshrn)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins//?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -90,9 +90,9 @@ plugin_routing:
       redirect: junipernetworks.junos.junos
     netconf:
       redirect: junipernetworks.junos.junos
-    junos_ospf:
+    junos_ospfv2:
       redirect: junipernetworks.junos.junos
-    ospf:
+    ospfv2:
       redirect: junipernetworks.junos.junos
     junos_package:
       redirect: junipernetworks.junos.junos
@@ -236,8 +236,8 @@ plugin_routing:
       redirect: junipernetworks.junos.junos_logging
     netconf:
       redirect: junipernetworks.junos.junos_netconf
-    ospf:
-      redirect: junipernetworks.junos.junos_ospf
+    ospfv2:
+      redirect: junipernetworks.junos.junos_ospfv2
     package:
       redirect: junipernetworks.junos.junos_package
     ping:

--- a/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
@@ -62,7 +62,13 @@ class InterfacesArgs(object):
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
@@ -38,7 +38,13 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/argspec/lacp/lacp.py
+++ b/plugins/module_utils/network/junos/argspec/lacp/lacp.py
@@ -49,7 +49,7 @@ class LacpArgs(object):
             },
         },
         "state": {
-            "choices": ["merged", "replaced", "deleted"],
+            "choices": ["merged", "replaced", "deleted", "gathered"],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/argspec/lacp_interfaces/lacp_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/lacp_interfaces/lacp_interfaces.py
@@ -63,7 +63,13 @@ class Lacp_interfacesArgs(object):
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/argspec/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/lag_interfaces/lag_interfaces.py
@@ -56,7 +56,13 @@ class Lag_interfacesArgs(object):
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/argspec/lldp_interfaces/lldp_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/lldp_interfaces/lldp_interfaces.py
@@ -47,7 +47,13 @@ class Lldp_interfacesArgs(object):
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "deleted", "overridden"],
+            "choices": [
+                "merged",
+                "replaced",
+                "deleted",
+                "overridden",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/argspec/static_routes/static_routes.py
+++ b/plugins/module_utils/network/junos/argspec/static_routes/static_routes.py
@@ -74,7 +74,13 @@ class Static_routesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/argspec/vlans/vlans.py
+++ b/plugins/module_utils/network/junos/argspec/vlans/vlans.py
@@ -48,7 +48,13 @@ class VlansArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
+++ b/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
@@ -69,10 +69,14 @@ class Acl_interfaces(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_acl_interfaces_facts = self.get_acl_interfaces_facts()
         config_xmls = self.set_config(existing_acl_interfaces_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_acl_interfaces_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/module_utils/network/junos/config/acls/acls.py
+++ b/plugins/module_utils/network/junos/config/acls/acls.py
@@ -69,10 +69,14 @@ class Acls(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_acls_facts = self.get_acls_facts()
         config_xmls = self.set_config(existing_acls_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_acls_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/module_utils/network/junos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/junos/config/interfaces/interfaces.py
@@ -70,10 +70,14 @@ class Interfaces(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
 
         existing_interfaces_facts = self.get_interfaces_facts()
-
         config_xmls = self.set_config(existing_interfaces_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_interfaces_facts
+
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):
                 diff = load_config(self._module, config_xml, [])

--- a/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
@@ -71,11 +71,15 @@ class L3_interfaces(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_interfaces_facts = self.get_l3_interfaces_facts()
-
         config_xmls = self.set_config(existing_interfaces_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_interfaces_facts
+
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):
                 diff = load_config(self._module, config_xml, warnings)

--- a/plugins/module_utils/network/junos/config/lacp/lacp.py
+++ b/plugins/module_utils/network/junos/config/lacp/lacp.py
@@ -70,9 +70,13 @@ class Lacp(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
 
         existing_lacp_facts = self.get_lacp_facts()
         config_xmls = self.set_config(existing_lacp_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_lacp_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
+++ b/plugins/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
@@ -70,9 +70,13 @@ class Lacp_interfaces(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
 
         existing_lacp_interfaces_facts = self.get_lacp_interfaces_facts()
         config_xmls = self.set_config(existing_lacp_interfaces_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_lacp_interfaces_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/module_utils/network/junos/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/junos/config/lag_interfaces/lag_interfaces.py
@@ -73,10 +73,14 @@ class Lag_interfaces(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_lag_interfaces_facts = self.get_lag_interfaces_facts()
         config_xmls = self.set_config(existing_lag_interfaces_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_lag_interfaces_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/module_utils/network/junos/config/lldp_interfaces/lldp_interfaces.py
+++ b/plugins/module_utils/network/junos/config/lldp_interfaces/lldp_interfaces.py
@@ -70,10 +70,14 @@ class Lldp_interfaces(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_lldp_interfaces_facts = self.get_lldp_interfaces_facts()
         config_xmls = self.set_config(existing_lldp_interfaces_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_lldp_interfaces_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/module_utils/network/junos/config/static_routes/static_routes.py
+++ b/plugins/module_utils/network/junos/config/static_routes/static_routes.py
@@ -71,10 +71,14 @@ class Static_routes(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_static_routes_facts = self.get_static_routes_facts()
         config_xmls = self.set_config(existing_static_routes_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_static_routes_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/module_utils/network/junos/config/vlans/vlans.py
+++ b/plugins/module_utils/network/junos/config/vlans/vlans.py
@@ -79,10 +79,14 @@ class Vlans(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_vlans_facts = self.get_vlans_facts()
         config_xmls = self.set_config(existing_vlans_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_vlans_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/modules/junos_acl_interfaces.py
+++ b/plugins/modules/junos_acl_interfaces.py
@@ -32,20 +32,20 @@ __metaclass__ = type
 
 
 DOCUMENTATION = """
----
 module: junos_acl_interfaces
 version_added: "1.0.0"
 short_description: Junos Access Control Lists (ACLs) interface resource module
 description:
-  - This module manages adding and removing Access Control Lists (ACLs) from interfaces on devices running Juniper JUNOS.
+- This module manages adding and removing Access Control Lists (ACLs) from interfaces
+  on devices running Juniper JUNOS.
 author: Daniel Mellado (@dmellado)
 requirements:
-  - ncclient (>=v0.6.4)
-  - xmltodict (>=0.12.0)
+- ncclient (>=v0.6.4)
+- xmltodict (>=0.12.0)
 notes:
-  - This module requires the netconf system service be enabled on the device being managed.
-  - This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
-  - Tested against JunOS v18.4R1
+- This module requires the netconf system service be enabled on the device being managed.
+- This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
+- Tested against JunOS v18.4R1
 options:
   config:
     description: A dictionary of ACL options for interfaces.
@@ -54,37 +54,38 @@ options:
     suboptions:
       name:
         description:
-          - Name/Identifier for the interface.
+        - Name/Identifier for the interface.
         type: str
       access_groups:
         type: list
         elements: dict
         description:
-          - Specifies ACLs attached to the interface.
+        - Specifies ACLs attached to the interface.
         suboptions:
           afi:
             description:
-              - Specifies the AFI for the ACL(s) to be configured on this interface.
+            - Specifies the AFI for the ACL(s) to be configured on this interface.
             type: str
-            choices: ['ipv4', 'ipv6']
+            choices: [ipv4, ipv6]
           acls:
             type: list
             description:
-              - Specifies the ACLs for the provided AFI.
+            - Specifies the ACLs for the provided AFI.
             elements: dict
             suboptions:
               name:
                 description:
-                  - Specifies the name of the IPv4/IPv4 ACL for the interface.
+                - Specifies the name of the IPv4/IPv4 ACL for the interface.
                 type: str
               direction:
                 description:
-                  - Specifies the direction of packets that the ACL will be applied on.
+                - Specifies the direction of packets that the ACL will be applied
+                  on.
                 type: str
-                choices: ['in', 'out']
+                choices: [in, out]
   state:
     description:
-      - The state the configuration should be left in.
+    - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -93,6 +94,7 @@ options:
     - deleted
     - gathered
     default: merged
+
 """
 EXAMPLES = """
 # Using deleted
@@ -118,15 +120,15 @@ EXAMPLES = """
 - name: Delete JUNOS L3 interface filter
   junipernetworks.junos.junos_acl_interfaces:
     config:
-      - name: ge-1/0/0
-        access_groups:
-          - afi: ipv4
-            acls:
-              - name: inbound_acl
-                direction: in
-              - name: outbound_acl
-                direction: out
-        state: deleted
+    - name: ge-1/0/0
+      access_groups:
+      - afi: ipv4
+        acls:
+        - name: inbound_acl
+          direction: in
+        - name: outbound_acl
+          direction: out
+      state: deleted
 
 # After state:
 # -------------
@@ -162,15 +164,15 @@ EXAMPLES = """
 - name: Merge JUNOS L3 interface filter
   junipernetworks.junos.junos_acl_interfaces:
     config:
-      - name: ge-1/0/0
-        access_groups:
-          - afi: ipv4
-            acls:
-              - name: inbound_acl
-                direction: in
-              - name: outbound_acl
-                direction: out
-        state: merged
+    - name: ge-1/0/0
+      access_groups:
+      - afi: ipv4
+        acls:
+        - name: inbound_acl
+          direction: in
+        - name: outbound_acl
+          direction: out
+      state: merged
 
 # After state:
 # -------------
@@ -213,15 +215,15 @@ EXAMPLES = """
 - name: Override JUNOS L3 interface filter
   junipernetworks.junos.junos_acl_interfaces:
     config:
-      - name: ge-1/0/0
-        access_groups:
-          - afi: ipv4
-            acls:
-              - name: inbound_acl
-                direction: in
-              - name: outbound_acl
-                direction: out
-        state: overridden
+    - name: ge-1/0/0
+      access_groups:
+      - afi: ipv4
+        acls:
+        - name: inbound_acl
+          direction: in
+        - name: outbound_acl
+          direction: out
+      state: overridden
 
 # After state:
 # -------------
@@ -265,13 +267,13 @@ EXAMPLES = """
 - name: Replace JUNOS L3 interface filter
   junipernetworks.junos.junos_acl_interfaces:
     config:
-      - name: ge-1/0/0
-        access_groups:
-          - afi: ipv4
-            acls:
-              - name: inbound_acl
-                direction: in
-        state: replaced
+    - name: ge-1/0/0
+      access_groups:
+      - afi: ipv4
+        acls:
+        - name: inbound_acl
+          direction: in
+      state: replaced
 
 # After state:
 # -------------

--- a/plugins/modules/junos_acl_interfaces.py
+++ b/plugins/modules/junos_acl_interfaces.py
@@ -30,17 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---
 module: junos_acl_interfaces
-version_added: "2.10"
-short_description: Manage adding and removing Access Control Lists (ACLs) from interfaces on devices running Juniper JUNOS.
+version_added: "1.0.0"
+short_description: Junos Access Control Lists (ACLs) interface resource module
 description:
   - This module manages adding and removing Access Control Lists (ACLs) from interfaces on devices running Juniper JUNOS.
 author: Daniel Mellado (@dmellado)

--- a/plugins/modules/junos_acl_interfaces.py
+++ b/plugins/modules/junos_acl_interfaces.py
@@ -117,7 +117,7 @@ EXAMPLES = """
 #     }
 
 - name: Delete JUNOS L3 interface filter
-  junos_acl_interfaces:
+  junipernetworks.junos.junos_acl_interfaces:
     config:
       - name: ge-1/0/0
         access_groups:
@@ -161,7 +161,7 @@ EXAMPLES = """
 #     }
 
 - name: Merge JUNOS L3 interface filter
-  junos_acl_interfaces:
+  junipernetworks.junos.junos_acl_interfaces:
     config:
       - name: ge-1/0/0
         access_groups:
@@ -212,7 +212,7 @@ EXAMPLES = """
 #     }
 
 - name: Override JUNOS L3 interface filter
-  junos_acl_interfaces:
+  junipernetworks.junos.junos_acl_interfaces:
     config:
       - name: ge-1/0/0
         access_groups:
@@ -264,7 +264,7 @@ EXAMPLES = """
 #     }
 
 - name: Replace JUNOS L3 interface filter
-  junos_acl_interfaces:
+  junipernetworks.junos.junos_acl_interfaces:
     config:
       - name: ge-1/0/0
         access_groups:

--- a/plugins/modules/junos_acl_interfaces.py
+++ b/plugins/modules/junos_acl_interfaces.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---

--- a/plugins/modules/junos_acls.py
+++ b/plugins/modules/junos_acls.py
@@ -32,19 +32,18 @@ __metaclass__ = type
 
 
 DOCUMENTATION = """
----
 module: junos_acls
 version_added: "1.0.0"
 short_description: Junos ACLs resource module
 description: This module provides declarative management of acls/filters on Juniper JUNOS devices
 author: Daniel Mellado (@dmellado)
 requirements:
-  - ncclient (>=v0.6.4)
-  - xmltodict (>=0.12.0)
+- ncclient (>=v0.6.4)
+- xmltodict (>=0.12.0)
 notes:
-  - This module requires the netconf system service be enabled on the device being managed.
-  - This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
-  - Tested against JunOS v18.4R1
+- This module requires the netconf system service be enabled on the device being managed.
+- This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
+- Tested against JunOS v18.4R1
 options:
   config:
     description: A dictionary of acls options
@@ -53,113 +52,113 @@ options:
     suboptions:
       afi:
         description:
-          - Protocol family to use by the acl filter
+        - Protocol family to use by the acl filter
         type: str
         required: true
         choices:
-          - ipv4
-          - ipv6
+        - ipv4
+        - ipv6
       acls:
         description:
-          - List of Access Control Lists (ACLs).
+        - List of Access Control Lists (ACLs).
         type: list
         elements: dict
         suboptions:
           name:
             description:
-              - Name to use for the acl filter
+            - Name to use for the acl filter
             type: str
             required: true
           aces:
             description:
-              - List of Access Control Entries (ACEs) for this Access Control List (ACL).
+            - List of Access Control Entries (ACEs) for this Access Control List (ACL).
             type: list
             elements: dict
             suboptions:
               name:
                 description:
-                  - Filter term name
+                - Filter term name
                 type: str
                 required: true
               grant:
                 description:
-                  - Action to take after matching condition (allow, discard/reject)
+                - Action to take after matching condition (allow, discard/reject)
                 type: str
-                choices: ['permit', 'deny']
+                choices: [permit, deny]
               source:
                 type: dict
                 description:
-                  - Specifies the source for the filter
+                - Specifies the source for the filter
                 suboptions:
                   address:
                     description:
-                      - IP source address to use for the filter
+                    - IP source address to use for the filter
                     type: str
                   prefix_list:
                     description:
-                      - IP source prefix list to use for the filter
+                    - IP source prefix list to use for the filter
                     type: str
                   port_protocol:
                     description:
-                      - Specify the source port or protocol.
+                    - Specify the source port or protocol.
                     type: dict
                     suboptions:
                       eq:
                         description:
-                          - Match only packets on a given port number.
+                        - Match only packets on a given port number.
                         type: str
                       range:
                         description:
-                          - Match only packets in the range of port numbers
+                        - Match only packets in the range of port numbers
                         type: dict
                         suboptions:
                           start:
                             description:
-                              - Specify the start of the port range
+                            - Specify the start of the port range
                             type: int
                           end:
                             description:
-                              - Specify the end of the port range
+                            - Specify the end of the port range
                             type: int
               destination:
                 type: dict
                 description:
-                  - Specifies the destination for the filter
+                - Specifies the destination for the filter
                 suboptions:
                   address:
                     description:
-                      - Match IP destination address
+                    - Match IP destination address
                     type: str
                   prefix_list:
                     description:
-                      - Match IP destination prefixes in named list
+                    - Match IP destination prefixes in named list
                     type: str
                   port_protocol:
                     description:
-                      - Specify the destination port or protocol.
+                    - Specify the destination port or protocol.
                     type: dict
                     suboptions:
                       eq:
                         description:
-                          - Match only packets on a given port number.
+                        - Match only packets on a given port number.
                         type: str
                       range:
                         description:
-                          - Match only packets in the range of port numbers
+                        - Match only packets in the range of port numbers
                         type: dict
                         suboptions:
                           start:
                             description:
-                              - Specify the start of the port range
+                            - Specify the start of the port range
                             type: int
                           end:
                             description:
-                              - Specify the end of the port range
+                            - Specify the end of the port range
                             type: int
               protocol:
                 description:
-                  - Specify the protocol to match.
-                  - Refer to vendor documentation for valid values.
+                - Specify the protocol to match.
+                - Refer to vendor documentation for valid values.
                 type: str
               protocol_options:
                 description: All possible suboptions for the protocol chosen.
@@ -243,19 +242,43 @@ options:
     - deleted
     - gathered
     default: merged
+
 """
 EXAMPLES = """
+# Using merged
 
+# Before state:
+# -------------
+#
+# admin# show firewall
 
+- name: Merge JUNOS acl
+  junipernetworks.junos.junos_acls:
+    config:
+    - afi: ipv4
+      acls:
+      - name: allow_ssh_acl
+        aces:
+        - name: ssh_rule
+          source:
+            port_protocol:
+              eq: ssh
+          protocol: tcp
+      state: merged
 
-
-
-
-
-
-
-
-
+# After state:
+# -------------
+# admin# show firewall
+# family inet {
+#     filter allow_ssh_acl {
+#         term ssh_rule {
+#             from {
+#                 protocol tcp;
+#                 source-port ssh;
+#             }
+#         }
+#     }
+# }
 
 """
 RETURN = """

--- a/plugins/modules/junos_acls.py
+++ b/plugins/modules/junos_acls.py
@@ -30,17 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---
 module: junos_acls
-version_added: "2.10"
-short_description: Manage acls on Juniper JUNOS devices
+version_added: "1.0.0"
+short_description: Junos ACLs resource module.
 description: This module provides declarative management of acls/filters on Juniper JUNOS devices
 author: Daniel Mellado (@dmellado)
 requirements:

--- a/plugins/modules/junos_acls.py
+++ b/plugins/modules/junos_acls.py
@@ -30,13 +30,12 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---
 module: junos_acls
 version_added: "1.0.0"
-short_description: Junos ACLs resource module.
+short_description: Junos ACLs resource module
 description: This module provides declarative management of acls/filters on Juniper JUNOS devices
 author: Daniel Mellado (@dmellado)
 requirements:

--- a/plugins/modules/junos_banner.py
+++ b/plugins/modules/junos_banner.py
@@ -44,7 +44,7 @@ options:
     description:
     - Specifies whether or not the configuration is active or deactivated
     type: bool
-    default: 'yes'
+    default: yes
 requirements:
 - ncclient (>=v0.5.2)
 notes:
@@ -59,7 +59,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: configure the login banner
-  junos_banner:
+  junipernetworks.junos.junos_banner:
     banner: login
     text: |
       this is my login banner
@@ -68,25 +68,25 @@ EXAMPLES = """
     state: present
 
 - name: remove the motd banner
-  junos_banner:
+  junipernetworks.junos.junos_banner:
     banner: motd
     state: absent
 
 - name: deactivate the motd banner
-  junos_banner:
+  junipernetworks.junos.junos_banner:
     banner: motd
     state: present
-    active: False
+    active: false
 
 - name: activate the motd banner
-  junos_banner:
+  junipernetworks.junos.junos_banner:
     banner: motd
     state: present
-    active: True
+    active: true
 
 - name: Configure banner from file
-  junos_banner:
-    banner:  motd
+  junipernetworks.junos.junos_banner:
+    banner: motd
     text: "{{ lookup('file', './config_partial/raw_banner.cfg') }}"
     state: present
 """

--- a/plugins/modules/junos_banner.py
+++ b/plugins/modules/junos_banner.py
@@ -9,13 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-DOCUMENTATION = """module: junos_banner
+DOCUMENTATION = """
+---
+module: junos_banner
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage multiline banners on Juniper JUNOS devices
 description:

--- a/plugins/modules/junos_command.py
+++ b/plugins/modules/junos_command.py
@@ -105,17 +105,17 @@ EXAMPLES = """
 - name: run multiple commands on remote nodes
   junipernetworks.junos.junos_command:
     commands:
-      - show version
-      - show interfaces
+    - show version
+    - show interfaces
 
 - name: run multiple commands and evaluate the output
   junipernetworks.junos.junos_command:
     commands:
-      - show version
-      - show interfaces
+    - show version
+    - show interfaces
     wait_for:
-      - result[0] contains Juniper
-      - result[1] contains Loopback0
+    - result[0] contains Juniper
+    - result[1] contains Loopback0
 
 - name: run commands and specify the output format
   junipernetworks.junos.junos_command:

--- a/plugins/modules/junos_command.py
+++ b/plugins/modules/junos_command.py
@@ -98,22 +98,22 @@ notes:
 
 EXAMPLES = """
 - name: run show version on remote devices
-  junos_command:
+  junipernetworks.junos.junos_command:
     commands: show version
 
 - name: run show version and check to see if output contains Juniper
-  junos_command:
+  junipernetworks.junos.junos_command:
     commands: show version
     wait_for: result[0] contains Juniper
 
 - name: run multiple commands on remote nodes
-  junos_command:
+  junipernetworks.junos.junos_command:
     commands:
       - show version
       - show interfaces
 
 - name: run multiple commands and evaluate the output
-  junos_command:
+  junipernetworks.junos.junos_command:
     commands:
       - show version
       - show interfaces
@@ -122,17 +122,17 @@ EXAMPLES = """
       - result[1] contains Loopback0
 
 - name: run commands and specify the output format
-  junos_command:
+  junipernetworks.junos.junos_command:
     commands: show version
     display: json
 
 - name: run rpc on the remote device
-  junos_command:
+  junipernetworks.junos.junos_command:
     commands: show configuration
     display: set
 
 - name: run rpc on the remote device
-  junos_command:
+  junipernetworks.junos.junos_command:
     rpcs: get-software-information
 """
 

--- a/plugins/modules/junos_command.py
+++ b/plugins/modules/junos_command.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_command
+DOCUMENTATION = """
+---
+module: junos_command
+version_added: "1.0.0"
 author: Peter Sprygada (@privateip)
 short_description: Run arbitrary commands on an Juniper JUNOS device
 description:

--- a/plugins/modules/junos_config.py
+++ b/plugins/modules/junos_config.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_config
+DOCUMENTATION = """
+---
+module: junos_config
+version_added: "1.0.0"
 author: Peter Sprygada (@privateip)
 short_description: Manage configuration on devices running Juniper JUNOS
 description:

--- a/plugins/modules/junos_config.py
+++ b/plugins/modules/junos_config.py
@@ -77,7 +77,7 @@ options:
       set the I(update) argument to C(replace). This argument will be removed in a
       future release. The C(replace) and C(update) argument is mutually exclusive.
     type: bool
-    default: 'no'
+    default: no
   backup:
     description:
     - This argument will cause the module to create a full backup of the current C(running-config)
@@ -86,7 +86,7 @@ options:
       playbook root directory or role root directory, if playbook is part of an ansible
       role. If the directory does not exist, it is created.
     type: bool
-    default: 'no'
+    default: no
   update:
     description:
     - This argument will decide how to load the configuration data particularly when
@@ -114,14 +114,14 @@ options:
     - This argument will execute commit operation on remote device. It can be used
       to confirm a previous commit.
     type: bool
-    default: 'no'
+    default: no
   check_commit:
     description:
     - This argument will check correctness of syntax; do not apply changes.
     - Note that this argument can be used to confirm verified configuration done via
       commit confirmed operation
     type: bool
-    default: 'no'
+    default: no
   backup_options:
     description:
     - This is a dict object containing configurable options related to backup file
@@ -167,16 +167,16 @@ EXAMPLES = """
 - name: load configure lines into device
   junipernetworks.junos.junos_config:
     lines:
-      - set interfaces ge-0/0/1 unit 0 description "Test interface"
-      - set vlans vlan01 description "Test vlan"
+    - set interfaces ge-0/0/1 unit 0 description "Test interface"
+    - set vlans vlan01 description "Test vlan"
     comment: update config
 
 - name: Set routed VLAN interface (RVI) IPv4 address
   junipernetworks.junos.junos_config:
     lines:
-      - set vlans vlan01 vlan-id 1
-      - set interfaces irb unit 10 family inet address 10.0.0.1/24
-      - set vlans vlan01 l3-interface irb.10
+    - set vlans vlan01 vlan-id 1
+    - set interfaces irb unit 10 family inet address 10.0.0.1/24
+    - set vlans vlan01 l3-interface irb.10
 
 - name: Check correctness of commit configuration
   junipernetworks.junos.junos_config:
@@ -193,9 +193,11 @@ EXAMPLES = """
 - name: Set VLAN access and trunking
   junipernetworks.junos.junos_config:
     lines:
-      - set vlans vlan02 vlan-id 6
-      - set interfaces ge-0/0/6.0 family ethernet-switching interface-mode access vlan members vlan02
-      - set interfaces ge-0/0/6.0 family ethernet-switching interface-mode trunk vlan members vlan02
+    - set vlans vlan02 vlan-id 6
+    - set interfaces ge-0/0/6.0 family ethernet-switching interface-mode access vlan
+      members vlan02
+    - set interfaces ge-0/0/6.0 family ethernet-switching interface-mode trunk vlan
+      members vlan02
 
 - name: confirm a previous commit
   junipernetworks.junos.junos_config:
@@ -205,7 +207,7 @@ EXAMPLES = """
   junipernetworks.junos.junos_config:
     lines:
       # - set int ge-0/0/1 unit 0 desc "Test interface"
-      - set interfaces ge-0/0/1 unit 0 description "Test interface"
+    - set interfaces ge-0/0/1 unit 0 description "Test interface"
 
 - name: configurable backup path
   junipernetworks.junos.junos_config:

--- a/plugins/modules/junos_config.py
+++ b/plugins/modules/junos_config.py
@@ -164,55 +164,55 @@ notes:
 
 EXAMPLES = """
 - name: load configure file into device
-  junos_config:
+  junipernetworks.junos.junos_config:
     src: srx.cfg
     comment: update config
 
 - name: load configure lines into device
-  junos_config:
+  junipernetworks.junos.junos_config:
     lines:
       - set interfaces ge-0/0/1 unit 0 description "Test interface"
       - set vlans vlan01 description "Test vlan"
     comment: update config
 
 - name: Set routed VLAN interface (RVI) IPv4 address
-  junos_config:
+  junipernetworks.junos.junos_config:
     lines:
       - set vlans vlan01 vlan-id 1
       - set interfaces irb unit 10 family inet address 10.0.0.1/24
       - set vlans vlan01 l3-interface irb.10
 
 - name: Check correctness of commit configuration
-  junos_config:
+  junipernetworks.junos.junos_config:
     check_commit: yes
 
 - name: rollback the configuration to id 10
-  junos_config:
+  junipernetworks.junos.junos_config:
     rollback: 10
 
 - name: zero out the current configuration
-  junos_config:
+  junipernetworks.junos.junos_config:
     zeroize: yes
 
 - name: Set VLAN access and trunking
-  junos_config:
+  junipernetworks.junos.junos_config:
     lines:
       - set vlans vlan02 vlan-id 6
       - set interfaces ge-0/0/6.0 family ethernet-switching interface-mode access vlan members vlan02
       - set interfaces ge-0/0/6.0 family ethernet-switching interface-mode trunk vlan members vlan02
 
 - name: confirm a previous commit
-  junos_config:
+  junipernetworks.junos.junos_config:
     confirm_commit: yes
 
 - name: for idempotency, use full-form commands
-  junos_config:
+  junipernetworks.junos.junos_config:
     lines:
       # - set int ge-0/0/1 unit 0 desc "Test interface"
       - set interfaces ge-0/0/1 unit 0 description "Test interface"
 
 - name: configurable backup path
-  junos_config:
+  junipernetworks.junos.junos_config:
     src: srx.cfg
     backup: yes
     backup_options:

--- a/plugins/modules/junos_facts.py
+++ b/plugins/modules/junos_facts.py
@@ -86,14 +86,14 @@ notes:
 
 EXAMPLES = """
 - name: collect default set of facts
-  junos_facts:
+  junipernetworks.junos.junos_facts:
 
 - name: collect default set of facts and configuration
-  junos_facts:
+  junipernetworks.junos.junos_facts:
     gather_subset: config
 
 - name: Gather legacy and resource facts
-  junos_facts:
+  junipernetworks.junos.junos_facts:
     gather_subset: all
     gather_network_resources: all
 """

--- a/plugins/modules/junos_facts.py
+++ b/plugins/modules/junos_facts.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_facts
+DOCUMENTATION = """
+---
+module: junos_facts
+version_added: "1.0.0"
 author: Nathaniel Case (@Qalthos)
 short_description: Collect facts from remote devices running Juniper Junos
 description:

--- a/plugins/modules/junos_interface.py
+++ b/plugins/modules/junos_interface.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
 module: junos_interface
 version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
-short_description: Manage Interface on Juniper JUNOS network devices
+short_description: (deprecated) Manage Interface on Juniper JUNOS network devices
 description:
 - This module provides declarative management of Interfaces on Juniper JUNOS network
   devices.
@@ -102,6 +102,7 @@ notes:
 - This module also works with C(local) connections for legacy playbooks.
 extends_documentation_fragment:
 - junipernetworks.junos.junos
+
 """
 
 EXAMPLES = """
@@ -118,24 +119,24 @@ EXAMPLES = """
 - name: make interface down
   junipernetworks.junos.junos_interface:
     name: ge-0/0/1
-    enabled: False
+    enabled: false
 
 - name: make interface up
   junipernetworks.junos.junos_interface:
     name: ge-0/0/1
-    enabled: True
+    enabled: true
 
 - name: Deactivate interface config
   junipernetworks.junos.junos_interface:
     name: ge-0/0/1
     state: present
-    active: False
+    active: false
 
 - name: Activate interface config
   junipernetworks.junos.junos_interface:
     name: ge-0/0/1
     state: present
-    active: True
+    active: true
 
 - name: Configure interface speed, mtu, duplex
   junipernetworks.junos.junos_interface:
@@ -148,10 +149,10 @@ EXAMPLES = """
 - name: Create interface using aggregate
   junipernetworks.junos.junos_interface:
     aggregate:
-      - name: ge-0/0/1
-        description: test-interface-1
-      - name: ge-0/0/2
-        description: test-interface-2
+    - name: ge-0/0/1
+      description: test-interface-1
+    - name: ge-0/0/2
+      description: test-interface-2
     speed: 1g
     duplex: full
     mtu: 512
@@ -159,8 +160,8 @@ EXAMPLES = """
 - name: Delete interface using aggregate
   junipernetworks.junos.junos_interface:
     aggregate:
-      - name: ge-0/0/1
-      - name: ge-0/0/2
+    - name: ge-0/0/1
+    - name: ge-0/0/2
     state: absent
 
 - name: Check intent arguments

--- a/plugins/modules/junos_interface.py
+++ b/plugins/modules/junos_interface.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["deprecated"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_interface
+DOCUMENTATION = """
+---
+module: junos_interface
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage Interface on Juniper JUNOS network devices
 description:

--- a/plugins/modules/junos_interface.py
+++ b/plugins/modules/junos_interface.py
@@ -110,39 +110,39 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: configure interface
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     name: ge-0/0/1
     description: test-interface
 
 - name: remove interface
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     name: ge-0/0/1
     state: absent
 
 - name: make interface down
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     name: ge-0/0/1
     enabled: False
 
 - name: make interface up
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     name: ge-0/0/1
     enabled: True
 
 - name: Deactivate interface config
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     name: ge-0/0/1
     state: present
     active: False
 
 - name: Activate interface config
-  net_interface:
+  junipernetworks.junos.junos_interface:
     name: ge-0/0/1
     state: present
     active: True
 
 - name: Configure interface speed, mtu, duplex
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     name: ge-0/0/1
     state: present
     speed: 1g
@@ -150,7 +150,7 @@ EXAMPLES = """
     duplex: full
 
 - name: Create interface using aggregate
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     aggregate:
       - name: ge-0/0/1
         description: test-interface-1
@@ -161,28 +161,28 @@ EXAMPLES = """
     mtu: 512
 
 - name: Delete interface using aggregate
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     aggregate:
       - name: ge-0/0/1
       - name: ge-0/0/2
     state: absent
 
 - name: Check intent arguments
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     name: "{{ name }}"
     state: up
     tx_rate: ge(0)
     rx_rate: le(0)
 
 - name: Check neighbor intent
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     name: xe-0/1/1
     neighbors:
     - port: Ethernet1/0/1
       host: netdev
 
 - name: Config + intent
-  junos_interface:
+  junipernetworks.junos.junos_interface:
     name: "{{ name }}"
     enabled: False
     state: down

--- a/plugins/modules/junos_interfaces.py
+++ b/plugins/modules/junos_interfaces.py
@@ -131,12 +131,12 @@ EXAMPLES = """
 - name: "Delete given options for the interface (Note: This won't delete the interface itself if any other values are configured for interface)"
   junipernetworks.junos.junos_interfaces:
     config:
-      - name: ge-0/0/1
-        description: 'Configured by Ansible-1'
-        speed: 1g
-        mtu: 1800
-      - name: ge-0/0/2
-        description: 'Configured by Ansible -2'
+    - name: ge-0/0/1
+      description: Configured by Ansible-1
+      speed: 1g
+      mtu: 1800
+    - name: ge-0/0/2
+      description: Configured by Ansible -2
     state: deleted
 
 # After state:
@@ -159,16 +159,16 @@ EXAMPLES = """
 #    speed 1g;
 # }
 
-- name: "Merge provided configuration with device configuration (default operation is merge)"
+- name: Merge provided configuration with device configuration (default operation is merge)
   junipernetworks.junos.junos_interfaces:
     config:
-      - name: ge-0/0/1
-        description: 'Configured by Ansible-1'
-        enabled: True
-        mtu: 1800
-      - name: ge-0/0/2
-        description: 'Configured by Ansible-2'
-        enabled: False
+    - name: ge-0/0/1
+      description: Configured by Ansible-1
+      enabled: true
+      mtu: 1800
+    - name: ge-0/0/2
+      description: Configured by Ansible-2
+      enabled: false
     state: merged
 
 # After state:
@@ -206,15 +206,15 @@ EXAMPLES = """
 #    description "Configured by Ansible-11";
 # }
 
-- name: "Override device configuration of all interfaces with provided configuration"
+- name: Override device configuration of all interfaces with provided configuration
   junipernetworks.junos.junos_interfaces:
     config:
-      - name: ge-0/0/2
-        description: 'Configured by Ansible-2'
-        enabled: False
-        mtu: 2800
-      - name: ge-0/0/3
-        description: 'Configured by Ansible-3'
+    - name: ge-0/0/2
+      description: Configured by Ansible-2
+      enabled: false
+      mtu: 2800
+    - name: ge-0/0/3
+      description: Configured by Ansible-3
     state: overridden
 
 # After state:
@@ -253,15 +253,15 @@ EXAMPLES = """
 #    description "Configured by Ansible-11";
 # }
 
-- name: "Replaces device configuration of listed interfaces with provided configuration"
+- name: Replaces device configuration of listed interfaces with provided configuration
   junipernetworks.junos.junos_interfaces:
     config:
-      - name: ge-0/0/2
-        description: 'Configured by Ansible-2'
-        enabled: False
-        mtu: 2800
-      - name: ge-0/0/3
-        description: 'Configured by Ansible-3'
+    - name: ge-0/0/2
+      description: Configured by Ansible-2
+      enabled: false
+      mtu: 2800
+    - name: ge-0/0/3
+      description: Configured by Ansible-3
     state: replaced
 
 # After state:

--- a/plugins/modules/junos_interfaces.py
+++ b/plugins/modules/junos_interfaces.py
@@ -130,7 +130,7 @@ EXAMPLES = """
 # }
 
 - name: "Delete given options for the interface (Note: This won't delete the interface itself if any other values are configured for interface)"
-  junos_interfaces:
+  junipernetworks.junos.junos_interfaces:
     config:
       - name: ge-0/0/1
         description: 'Configured by Ansible-1'
@@ -161,7 +161,7 @@ EXAMPLES = """
 # }
 
 - name: "Merge provided configuration with device configuration (default operation is merge)"
-  junos_interfaces:
+  junipernetworks.junos.junos_interfaces:
     config:
       - name: ge-0/0/1
         description: 'Configured by Ansible-1'
@@ -208,7 +208,7 @@ EXAMPLES = """
 # }
 
 - name: "Override device configuration of all interfaces with provided configuration"
-  junos_interfaces:
+  junipernetworks.junos.junos_interfaces:
     config:
       - name: ge-0/0/2
         description: 'Configured by Ansible-2'
@@ -255,7 +255,7 @@ EXAMPLES = """
 # }
 
 - name: "Replaces device configuration of listed interfaces with provided configuration"
-  junos_interfaces:
+  junipernetworks.junos.junos_interfaces:
     config:
       - name: ge-0/0/2
         description: 'Configured by Ansible-2'

--- a/plugins/modules/junos_interfaces.py
+++ b/plugins/modules/junos_interfaces.py
@@ -30,14 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_interfaces
-short_description: Manages interface attributes of Juniper Junos OS network devices.
+DOCUMENTATION = """
+---
+module: junos_interfaces
+version_added: "1.0.0"
+short_description: Junos Interfaces resource module
 description: This module manages the interfaces on Juniper Junos OS network devices.
 author: Ganesh Nalawade (@ganeshrn)
 options:
@@ -99,6 +98,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
     description:
     - The state of the configuration after module completion

--- a/plugins/modules/junos_interfaces.py
+++ b/plugins/modules/junos_interfaces.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---

--- a/plugins/modules/junos_l2_interface.py
+++ b/plugins/modules/junos_l2_interface.py
@@ -95,7 +95,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Configure interface in access mode
-  junos_l2_interface:
+  junipernetworks.junos.junos_l2_interface:
     name: ge-0/0/1
     description: interface-access
     mode: access
@@ -104,7 +104,7 @@ EXAMPLES = """
     state: present
 
 - name: Configure interface in trunk mode
-  junos_l2_interface:
+  junipernetworks.junos.junos_l2_interface:
     name: ge-0/0/1
     description: interface-trunk
     mode: trunk
@@ -116,7 +116,7 @@ EXAMPLES = """
     state: present
 
 - name: Configure interface in access and trunk mode using aggregate
-  junos_l2_interface:
+  junipernetworks.junos.junos_l2_interface:
     aggregate:
     - name: ge-0/0/1
       description: test-interface-access

--- a/plugins/modules/junos_l2_interface.py
+++ b/plugins/modules/junos_l2_interface.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["deprecated"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_l2_interface
+DOCUMENTATION = """
+---
+module: junos_l2_interface
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage Layer-2 interface on Juniper JUNOS network devices
 description:

--- a/plugins/modules/junos_l2_interface.py
+++ b/plugins/modules/junos_l2_interface.py
@@ -13,8 +13,10 @@ DOCUMENTATION = """
 ---
 module: junos_l2_interface
 version_added: "1.0.0"
+module: junos_l2_interface
 author: Ganesh Nalawade (@ganeshrn)
-short_description: Manage Layer-2 interface on Juniper JUNOS network devices
+short_description: (deprecated) Manage Layer-2 interface on Juniper JUNOS network
+  devices
 description:
 - This module provides declarative management of Layer-2 interface on Juniper JUNOS
   network devices.
@@ -87,6 +89,7 @@ notes:
 - This module also works with C(local) connections for legacy playbooks.
 extends_documentation_fragment:
 - junipernetworks.junos.junos
+
 """
 
 EXAMPLES = """
@@ -96,7 +99,7 @@ EXAMPLES = """
     description: interface-access
     mode: access
     access_vlan: red
-    active: True
+    active: true
     state: present
 
 - name: Configure interface in trunk mode
@@ -108,7 +111,7 @@ EXAMPLES = """
     - blue
     - green
     native_vlan: 100
-    active: True
+    active: true
     state: present
 
 - name: Configure interface in access and trunk mode using aggregate
@@ -125,7 +128,7 @@ EXAMPLES = """
       - blue
       - green
       native_vlan: 100
-    active: True
+    active: true
     state: present
 """
 

--- a/plugins/modules/junos_l2_interfaces.py
+++ b/plugins/modules/junos_l2_interfaces.py
@@ -32,12 +32,11 @@ __metaclass__ = type
 
 
 DOCUMENTATION = """
----
 module: junos_l2_interfaces
-version_added: "1.0.0"
-short_description: JUNOS L2 interfaces resource module
+short_description: L2 interfaces resource module
 description: This module provides declarative management of a Layer-2 interface on
   Juniper JUNOS devices.
+version_added: 1.0.0
 author: Ganesh Nalawade (@ganeshrn)
 options:
   config:
@@ -102,6 +101,7 @@ notes:
   being managed.
 - Tested against vSRX JUNOS version 18.4R1.
 - This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
+
 """
 EXAMPLES = """
 # Using deleted
@@ -133,8 +133,8 @@ EXAMPLES = """
 - name: "Delete L2 attributes of given interfaces (Note: This won't delete the interface itself)."
   junipernetworks.junos.junos_l2_interfaces:
     config:
-      - name: ge-0/0/1
-      - name: ge-0/0/2
+    - name: ge-0/0/1
+    - name: ge-0/0/2
     state: deleted
 
 # After state:
@@ -176,17 +176,17 @@ EXAMPLES = """
 #    }
 # }
 
-- name: "Merge provided configuration with device configuration (default operation is merge)"
+- name: Merge provided configuration with device configuration (default operation is merge)
   junipernetworks.junos.junos_l2_interfaces:
     config:
-      - name: ge-0/0/3
-        access:
-          vlan: v101
-      - name: ge-0/0/4
-        trunk:
-          allowed_vlans:
-            - vlan30
-          native_vlan: 50
+    - name: ge-0/0/3
+      access:
+        vlan: v101
+    - name: ge-0/0/4
+      trunk:
+        allowed_vlans:
+        - vlan30
+        native_vlan: 50
     state: merged
 
 # After state:
@@ -251,17 +251,17 @@ EXAMPLES = """
 #    }
 # }
 
-- name: "Override provided configuration with device configuration"
+- name: Override provided configuration with device configuration
   junipernetworks.junos.junos_l2_interfaces:
     config:
-      - name: ge-0/0/3
-        access:
-          vlan: v101
-      - name: ge-0/0/4
-        trunk:
-          allowed_vlans:
-            - vlan30
-          native_vlan: 50
+    - name: ge-0/0/3
+      access:
+        vlan: v101
+    - name: ge-0/0/4
+      trunk:
+        allowed_vlans:
+        - vlan30
+        native_vlan: 50
     state: overridden
 
 # After state:
@@ -313,17 +313,17 @@ EXAMPLES = """
 #    }
 # }
 
-- name: "Replace provided configuration with device configuration"
+- name: Replace provided configuration with device configuration
   junipernetworks.junos.junos_l2_interfaces:
     config:
-      - name: ge-0/0/3
-        access:
-          vlan: v101
-      - name: ge-0/0/4
-        trunk:
-          allowed_vlans:
-            - vlan30
-          native_vlan: 50
+    - name: ge-0/0/3
+      access:
+        vlan: v101
+    - name: ge-0/0/4
+      trunk:
+        allowed_vlans:
+        - vlan30
+        native_vlan: 50
     state: replaced
 
 # After state:

--- a/plugins/modules/junos_l2_interfaces.py
+++ b/plugins/modules/junos_l2_interfaces.py
@@ -132,7 +132,7 @@ EXAMPLES = """
 #    }
 
 - name: "Delete L2 attributes of given interfaces (Note: This won't delete the interface itself)."
-  junos_l2_interfaces:
+  junipernetworks.junos.junos_l2_interfaces:
     config:
       - name: ge-0/0/1
       - name: ge-0/0/2
@@ -178,7 +178,7 @@ EXAMPLES = """
 # }
 
 - name: "Merge provided configuration with device configuration (default operation is merge)"
-  junos_l2_interfaces:
+  junipernetworks.junos.junos_l2_interfaces:
     config:
       - name: ge-0/0/3
         access:
@@ -253,7 +253,7 @@ EXAMPLES = """
 # }
 
 - name: "Override provided configuration with device configuration"
-  junos_l2_interfaces:
+  junipernetworks.junos.junos_l2_interfaces:
     config:
       - name: ge-0/0/3
         access:
@@ -315,7 +315,7 @@ EXAMPLES = """
 # }
 
 - name: "Replace provided configuration with device configuration"
-  junos_l2_interfaces:
+  junipernetworks.junos.junos_l2_interfaces:
     config:
       - name: ge-0/0/3
         access:

--- a/plugins/modules/junos_l2_interfaces.py
+++ b/plugins/modules/junos_l2_interfaces.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---

--- a/plugins/modules/junos_l3_interface.py
+++ b/plugins/modules/junos_l3_interface.py
@@ -80,17 +80,17 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Set ge-0/0/1 IPv4 address
-  junos_l3_interface:
+  junipernetworks.junos.junos_l3_interface:
     name: ge-0/0/1
     ipv4: 192.168.0.1
 
 - name: Remove ge-0/0/1 IPv4 address
-  junos_l3_interface:
+  junipernetworks.junos.junos_l3_interface:
     name: ge-0/0/1
     state: absent
 
 - name: Set ipv4 address using aggregate
-  junos_l3_interface:
+  junipernetworks.junos.junos_l3_interface:
     aggregate:
     - name: ge-0/0/1
       ipv4: 192.0.2.1
@@ -99,7 +99,7 @@ EXAMPLES = """
       ipv6: fd5d:12c9:2201:2::2
 
 - name: Delete ipv4 address using aggregate
-  junos_l3_interface:
+  junipernetworks.junos.junos_l3_interface:
     aggregate:
     - name: ge-0/0/1
       ipv4: 192.0.2.1

--- a/plugins/modules/junos_l3_interface.py
+++ b/plugins/modules/junos_l3_interface.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["deprecated"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_l3_interface
+DOCUMENTATION = """
+---
+module: junos_l3_interface
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage L3 interfaces on Juniper JUNOS network devices
 description:

--- a/plugins/modules/junos_l3_interface.py
+++ b/plugins/modules/junos_l3_interface.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
 module: junos_l3_interface
 version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
-short_description: Manage L3 interfaces on Juniper JUNOS network devices
+short_description: (deprecated) Manage L3 interfaces on Juniper JUNOS network devices
 description:
 - This module provides declarative management of L3 interfaces on Juniper JUNOS network
   devices.
@@ -72,6 +72,7 @@ notes:
 - This module also works with C(local) connections for legacy playbooks.
 extends_documentation_fragment:
 - junipernetworks.junos.junos
+
 """
 
 EXAMPLES = """

--- a/plugins/modules/junos_l3_interfaces.py
+++ b/plugins/modules/junos_l3_interfaces.py
@@ -30,14 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_l3_interfaces
-short_description: Manage Layer 3 interface on Juniper JUNOS devices
+DOCUMENTATION = """
+---
+module: junos_l3_interfaces
+version_added: "1.0.0"
+short_description: Junos L3 Interfaces resource module
 description: This module provides declarative management of a Layer 3 interface on
   Juniper JUNOS devices
 author: Daniel Mellado (@dmellado)
@@ -98,6 +97,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
 """
 EXAMPLES = """

--- a/plugins/modules/junos_l3_interfaces.py
+++ b/plugins/modules/junos_l3_interfaces.py
@@ -128,7 +128,7 @@ EXAMPLES = """
 # }
 
 - name: Delete JUNOS L3 logical interface
-  junos_l3_interfaces:
+  junipernetworks.junos.junos_l3_interfaces:
     config:
       - name: ge-0/0/1
       - name: ge-0/0/2
@@ -174,7 +174,7 @@ EXAMPLES = """
 # }
 
 - name: Merge provided configuration with device configuration (default operation is merge)
-  junos_l3_interfaces:
+  junipernetworks.junos.junos_l3_interfaces:
     config:
       - name: ge-0/0/1
         ipv4:
@@ -244,7 +244,7 @@ EXAMPLES = """
 # }
 
 - name: Override provided configuration with device configuration
-  junos_l3_interfaces:
+  junipernetworks.junos.junos_l3_interfaces:
     config:
       - name: ge-0/0/1
         ipv4:
@@ -313,7 +313,7 @@ EXAMPLES = """
 # }
 
 - name: Replace provided configuration with device configuration
-  junos_l3_interfaces:
+  junipernetworks.junos.junos_l3_interfaces:
     config:
       - name: ge-0/0/1
         ipv4:

--- a/plugins/modules/junos_l3_interfaces.py
+++ b/plugins/modules/junos_l3_interfaces.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---

--- a/plugins/modules/junos_l3_interfaces.py
+++ b/plugins/modules/junos_l3_interfaces.py
@@ -98,6 +98,7 @@ options:
     - deleted
     - gathered
     default: merged
+
 """
 EXAMPLES = """
 # Using deleted
@@ -129,8 +130,8 @@ EXAMPLES = """
 - name: Delete JUNOS L3 logical interface
   junipernetworks.junos.junos_l3_interfaces:
     config:
-      - name: ge-0/0/1
-      - name: ge-0/0/2
+    - name: ge-0/0/1
+    - name: ge-0/0/2
   state: deleted
 
 # After state:
@@ -175,14 +176,14 @@ EXAMPLES = """
 - name: Merge provided configuration with device configuration (default operation is merge)
   junipernetworks.junos.junos_l3_interfaces:
     config:
-      - name: ge-0/0/1
-        ipv4:
-           - address: 192.168.1.10/24
-        ipv6:
-           - address: 8d8d:8d01::1/64
-      - name: ge-0/0/2
-        ipv4:
-           - address: dhcp
+    - name: ge-0/0/1
+      ipv4:
+      - address: 192.168.1.10/24
+      ipv6:
+      - address: 8d8d:8d01::1/64
+    - name: ge-0/0/2
+      ipv4:
+      - address: dhcp
     state: merged
 
 # After state:
@@ -245,14 +246,14 @@ EXAMPLES = """
 - name: Override provided configuration with device configuration
   junipernetworks.junos.junos_l3_interfaces:
     config:
-      - name: ge-0/0/1
-        ipv4:
-           - address: 192.168.1.10/24
-        ipv6:
-           - address: 8d8d:8d01::1/64
-      - name: ge-0/0/2
-        ipv6:
-           - address: 2001:db8:3000::/64
+    - name: ge-0/0/1
+      ipv4:
+      - address: 192.168.1.10/24
+      ipv6:
+      - address: 8d8d:8d01::1/64
+    - name: ge-0/0/2
+      ipv6:
+      - address: 2001:db8:3000::/64
     state: overridden
 
 # After state:
@@ -314,14 +315,14 @@ EXAMPLES = """
 - name: Replace provided configuration with device configuration
   junipernetworks.junos.junos_l3_interfaces:
     config:
-      - name: ge-0/0/1
-        ipv4:
-           - address: 192.168.1.10/24
-        ipv6:
-           - address: 8d8d:8d01::1/64
-      - name: ge-0/0/2
-        ipv4:
-           - address: dhcp
+    - name: ge-0/0/1
+      ipv4:
+      - address: 192.168.1.10/24
+      ipv6:
+      - address: 8d8d:8d01::1/64
+    - name: ge-0/0/2
+      ipv4:
+      - address: dhcp
     state: replaced
 
 # After state:

--- a/plugins/modules/junos_lacp.py
+++ b/plugins/modules/junos_lacp.py
@@ -30,15 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_lacp
-short_description: Manage Global Link Aggregation Control Protocol (LACP) on Juniper
-  Junos devices
+DOCUMENTATION = """
+---
+module: junos_lacp
+version_added: "1.0.0"
+short_description: Global Link Aggregation Control Protocol (LACP) Junos resource module
 description: This module provides declarative management of global LACP on Juniper
   Junos network devices.
 author: Ganesh Nalawade (@ganeshrn)
@@ -68,6 +66,7 @@ options:
     - merged
     - replaced
     - deleted
+    - gathered
     default: merged
 requirements:
 - ncclient (>=v0.6.4)

--- a/plugins/modules/junos_lacp.py
+++ b/plugins/modules/junos_lacp.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---

--- a/plugins/modules/junos_lacp.py
+++ b/plugins/modules/junos_lacp.py
@@ -88,7 +88,7 @@ EXAMPLES = """
 # }
 
 - name: Delete global LACP attributes
-  junos_lacp:
+  junipernetworks.junos.junos_lacp:
     state: deleted
 
 # After state:
@@ -105,7 +105,7 @@ EXAMPLES = """
 #
 
 - name: Merge global LACP attributes
-  junos_lacp:
+  junipernetworks.junos.junos_lacp:
     config:
       system_priority: 63
       link_protection: revertive
@@ -131,7 +131,7 @@ EXAMPLES = """
 # }
 
 - name: Replace global LACP attributes
-  junos_lacp:
+  junipernetworks.junos.junos_lacp:
     config:
       system_priority: 30
       link_protection: non-revertive

--- a/plugins/modules/junos_lacp_interfaces.py
+++ b/plugins/modules/junos_lacp_interfaces.py
@@ -30,15 +30,14 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_lacp_interfaces
-short_description: Manage Link Aggregation Control Protocol (LACP) attributes of interfaces
-  on Juniper JUNOS devices.
+DOCUMENTATION = """
+---
+module: junos_lacp_interfaces
+version_added: "1.0.0"
+short_description: Junos Link Aggregation Control Protocol (LACP)  interfaces
+  resource module.
 description:
 - This module manages Link Aggregation Control Protocol (LACP) attributes of interfaces
   on Juniper JUNOS devices.
@@ -116,6 +115,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
 """
 EXAMPLES = """

--- a/plugins/modules/junos_lacp_interfaces.py
+++ b/plugins/modules/junos_lacp_interfaces.py
@@ -115,6 +115,7 @@ options:
     - deleted
     - gathered
     default: merged
+
 """
 EXAMPLES = """
 # Using merged
@@ -152,16 +153,16 @@ EXAMPLES = """
 - name: Merge provided configuration with device configuration
   junipernetworks.junos.junos_lacp_interfaces:
     config:
-      - name: ae0
-        period: fast
-        sync_reset: enable
-        system:
-          priority: 100
-          mac:
-            address: 00:00:00:00:00:02
-      - name: ge-0/0/3
-        port_priority: 100
-        force_up: True
+    - name: ae0
+      period: fast
+      sync_reset: enable
+      system:
+        priority: 100
+        mac:
+          address: 00:00:00:00:00:02
+    - name: ge-0/0/3
+      port_priority: 100
+      force_up: true
     state: merged
 
 # After state:
@@ -250,8 +251,8 @@ EXAMPLES = """
 - name: Replace device LACP interfaces configuration with provided configuration
   junipernetworks.junos.junos_lacp_interfaces:
     config:
-      - name: ae0
-        period: slow
+    - name: ae0
+      period: slow
     state: replaced
 
 # After state:
@@ -334,14 +335,14 @@ EXAMPLES = """
 - name: Overrides all device LACP interfaces configuration with provided configuration
   junipernetworks.junos.junos_lacp_interfaces:
     config:
-      - name: ae0
-        system:
-          priority: 300
-          mac:
-            address: 00:00:00:00:00:03
-      - name: ge-0/0/2
-        port_priority: 200
-        force_up: False
+    - name: ae0
+      system:
+        priority: 300
+        mac:
+          address: 00:00:00:00:00:03
+    - name: ge-0/0/2
+      port_priority: 200
+      force_up: false
     state: overridden
 
 # After state:
@@ -436,9 +437,9 @@ EXAMPLES = """
 - name: "Delete LACP interfaces attributes of given interfaces (Note: This won't delete the interface itself)"
   junipernetworks.junos.junos_lacp_interfaces:
     config:
-      - name: ae0
-      - name: ge-0/0/3
-      - name: ge-0/0/2
+    - name: ae0
+    - name: ge-0/0/3
+    - name: ge-0/0/2
     state: deleted
 
 # After state:

--- a/plugins/modules/junos_lacp_interfaces.py
+++ b/plugins/modules/junos_lacp_interfaces.py
@@ -30,14 +30,12 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---
 module: junos_lacp_interfaces
 version_added: "1.0.0"
 short_description: Junos Link Aggregation Control Protocol (LACP)  interfaces
-  resource module.
 description:
 - This module manages Link Aggregation Control Protocol (LACP) attributes of interfaces
   on Juniper JUNOS devices.

--- a/plugins/modules/junos_lacp_interfaces.py
+++ b/plugins/modules/junos_lacp_interfaces.py
@@ -152,7 +152,7 @@ EXAMPLES = """
 # }
 
 - name: Merge provided configuration with device configuration
-  junos_lacp_interfaces:
+  junipernetworks.junos.junos_lacp_interfaces:
     config:
       - name: ae0
         period: fast
@@ -250,7 +250,7 @@ EXAMPLES = """
 # }
 
 - name: Replace device LACP interfaces configuration with provided configuration
-  junos_lacp_interfaces:
+  junipernetworks.junos.junos_lacp_interfaces:
     config:
       - name: ae0
         period: slow
@@ -334,7 +334,7 @@ EXAMPLES = """
 # }
 
 - name: Overrides all device LACP interfaces configuration with provided configuration
-  junos_lacp_interfaces:
+  junipernetworks.junos.junos_lacp_interfaces:
     config:
       - name: ae0
         system:
@@ -436,7 +436,7 @@ EXAMPLES = """
 # }
 
 - name: "Delete LACP interfaces attributes of given interfaces (Note: This won't delete the interface itself)"
-  junos_lacp_interfaces:
+  junipernetworks.junos.junos_lacp_interfaces:
     config:
       - name: ae0
       - name: ge-0/0/3

--- a/plugins/modules/junos_lag_interfaces.py
+++ b/plugins/modules/junos_lag_interfaces.py
@@ -128,8 +128,8 @@ EXAMPLES = """
 - name: "Delete LAG attributes of given interfaces (Note: This won't delete the interface itself)"
   junipernetworks.junos.junos_lag_interfaces:
     config:
-      - name: ae0
-      - name: ae1
+    - name: ae0
+    - name: ae1
     state: deleted
 
 # After state:
@@ -158,12 +158,12 @@ EXAMPLES = """
 - name: Merge provided configuration with device configuration
   junipernetworks.junos.junos_lag_interfaces:
     config:
-      - name: ae0
-        members:
-          - member: ge-0/0/1
-            link_type: primary
-          - member: ge-0/0/2
-            link_type: backup
+    - name: ae0
+      members:
+      - member: ge-0/0/1
+        link_type: primary
+      - member: ge-0/0/2
+        link_type: backup
     state: merged
 
 # After state:
@@ -216,13 +216,13 @@ EXAMPLES = """
 - name: Overrides all device LAG configuration with provided configuration
   junipernetworks.junos.junos_lag_interfaces:
     config:
-      - name: ae0
-        members:
-          - member: ge-0/0/2
-      - name: ae1
-        members:
-          - member: ge-0/0/1
-        mode: passive
+    - name: ae0
+      members:
+      - member: ge-0/0/2
+    - name: ae1
+      members:
+      - member: ge-0/0/1
+      mode: passive
     state: overridden
 
 # After state:
@@ -270,10 +270,10 @@ EXAMPLES = """
 - name: Replace device LAG configuration with provided configuration
   junipernetworks.junos.junos_lag_interfaces:
     config:
-      - name: ae0
-        members:
-          - member: ge-0/0/1
-        mode: active
+    - name: ae0
+      members:
+      - member: ge-0/0/1
+      mode: active
     state: replaced
 
 # After state:

--- a/plugins/modules/junos_lag_interfaces.py
+++ b/plugins/modules/junos_lag_interfaces.py
@@ -127,7 +127,7 @@ EXAMPLES = """
 # }
 
 - name: "Delete LAG attributes of given interfaces (Note: This won't delete the interface itself)"
-  junos_lag_interfaces:
+  junipernetworks.junos.junos_lag_interfaces:
     config:
       - name: ae0
       - name: ae1
@@ -157,7 +157,7 @@ EXAMPLES = """
 # }
 
 - name: Merge provided configuration with device configuration
-  junos_lag_interfaces:
+  junipernetworks.junos.junos_lag_interfaces:
     config:
       - name: ae0
         members:
@@ -215,7 +215,7 @@ EXAMPLES = """
 # }
 
 - name: Overrides all device LAG configuration with provided configuration
-  junos_lag_interfaces:
+  junipernetworks.junos.junos_lag_interfaces:
     config:
       - name: ae0
         members:
@@ -269,7 +269,7 @@ EXAMPLES = """
 # }
 
 - name: Replace device LAG configuration with provided configuration
-  junos_lag_interfaces:
+  junipernetworks.junos.junos_lag_interfaces:
     config:
       - name: ae0
         members:

--- a/plugins/modules/junos_lag_interfaces.py
+++ b/plugins/modules/junos_lag_interfaces.py
@@ -30,14 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_lag_interfaces
-short_description: Manage Link Aggregation on Juniper JUNOS devices.
+DOCUMENTATION = """
+---
+module: junos_lag_interfaces
+version_added: "1.0.0"
+short_description: Link Aggregation Juniper JUNOS resource module
 description: This module manages properties of Link Aggregation Group on Juniper JUNOS
   devices.
 author: Ganesh Nalawade (@ganeshrn)
@@ -92,6 +91,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
 requirements:
 - ncclient (>=v0.6.4)

--- a/plugins/modules/junos_lag_interfaces.py
+++ b/plugins/modules/junos_lag_interfaces.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---

--- a/plugins/modules/junos_linkagg.py
+++ b/plugins/modules/junos_linkagg.py
@@ -14,7 +14,8 @@ DOCUMENTATION = """
 module: junos_linkagg
 version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
-short_description: Manage link aggregation groups on Juniper JUNOS network devices
+short_description: (deprecated) Manage link aggregation groups on Juniper JUNOS network
+  devices
 description:
 - This module provides declarative management of link aggregation groups on Juniper
   JUNOS network devices.
@@ -36,8 +37,8 @@ options:
       disable LACP.
     default: false
     choices:
-    - 'on'
-    - 'off'
+    - on
+    - off
     - active
     - passive
   members:
@@ -81,6 +82,7 @@ notes:
 - This module also works with C(local) connections for legacy playbooks.
 extends_documentation_fragment:
 - junipernetworks.junos.junos
+
 """
 
 EXAMPLES = """
@@ -88,9 +90,9 @@ EXAMPLES = """
   junipernetworks.junos.junos_linkagg:
     name: ae11
     members:
-      - ge-0/0/5
-      - ge-0/0/6
-      - ge-0/0/7
+    - ge-0/0/5
+    - ge-0/0/6
+    - ge-0/0/7
     lacp: active
     device_count: 4
     state: present
@@ -99,9 +101,9 @@ EXAMPLES = """
   junipernetworks.junos.junos_linkagg:
     name: ae11
     members:
-      - ge-0/0/5
-      - ge-0/0/6
-      - ge-0/0/7
+    - ge-0/0/5
+    - ge-0/0/6
+    - ge-0/0/7
     lacp: active
     device_count: 4
     state: delete
@@ -110,25 +112,25 @@ EXAMPLES = """
   junipernetworks.junos.junos_linkagg:
     name: ae11
     members:
-      - ge-0/0/5
-      - ge-0/0/6
-      - ge-0/0/7
+    - ge-0/0/5
+    - ge-0/0/6
+    - ge-0/0/7
     lacp: active
     device_count: 4
     state: present
-    active: False
+    active: false
 
 - name: Activate link aggregation
   junipernetworks.junos.junos_linkagg:
     name: ae11
     members:
-      - ge-0/0/5
-      - ge-0/0/6
-      - ge-0/0/7
+    - ge-0/0/5
+    - ge-0/0/6
+    - ge-0/0/7
     lacp: active
     device_count: 4
     state: present
-    active: True
+    active: true
 
 - name: Disable link aggregation
   junipernetworks.junos.junos_linkagg:

--- a/plugins/modules/junos_linkagg.py
+++ b/plugins/modules/junos_linkagg.py
@@ -89,7 +89,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: configure link aggregation
-  junos_linkagg:
+  junipernetworks.junos.junos_linkagg:
     name: ae11
     members:
       - ge-0/0/5
@@ -100,7 +100,7 @@ EXAMPLES = """
     state: present
 
 - name: delete link aggregation
-  junos_linkagg:
+  junipernetworks.junos.junos_linkagg:
     name: ae11
     members:
       - ge-0/0/5
@@ -111,7 +111,7 @@ EXAMPLES = """
     state: delete
 
 - name: deactivate link aggregation
-  junos_linkagg:
+  junipernetworks.junos.junos_linkagg:
     name: ae11
     members:
       - ge-0/0/5
@@ -123,7 +123,7 @@ EXAMPLES = """
     active: False
 
 - name: Activate link aggregation
-  junos_linkagg:
+  junipernetworks.junos.junos_linkagg:
     name: ae11
     members:
       - ge-0/0/5
@@ -135,12 +135,12 @@ EXAMPLES = """
     active: True
 
 - name: Disable link aggregation
-  junos_linkagg:
+  junipernetworks.junos.junos_linkagg:
     name: ae11
     state: down
 
 - name: Enable link aggregation
-  junos_linkagg:
+  junipernetworks.junos.junos_linkagg:
     name: ae11
     state: up
 """

--- a/plugins/modules/junos_linkagg.py
+++ b/plugins/modules/junos_linkagg.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["deprecated"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_linkagg
+DOCUMENTATION = """
+---
+module: junos_linkagg
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage link aggregation groups on Juniper JUNOS network devices
 description:

--- a/plugins/modules/junos_lldp.py
+++ b/plugins/modules/junos_lldp.py
@@ -71,22 +71,22 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Enable LLDP service
-  junos_lldp:
+  junipernetworks.junos.junos_lldp:
     state: enabled
 
 - name: Disable LLDP service
-  junos_lldp:
+  junipernetworks.junos.junos_lldp:
     state: disabled
 
 - name: Set LLDP parameters
-  junos_lldp:
+  junipernetworks.junos.junos_lldp:
     interval: 10
     hold_multiplier: 5
     transmit_delay: 30
     state: present
 
 - name: Delete LLDP parameters
-  junos_lldp:
+  junipernetworks.junos.junos_lldp:
     interval: 10
     hold_multiplier: 5
     transmit_delay: 30

--- a/plugins/modules/junos_lldp.py
+++ b/plugins/modules/junos_lldp.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["deprecated"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_lldp
+DOCUMENTATION = """
+---
+module: junos_lldp
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage LLDP configuration on Juniper JUNOS network devices
 description:

--- a/plugins/modules/junos_lldp.py
+++ b/plugins/modules/junos_lldp.py
@@ -14,7 +14,8 @@ DOCUMENTATION = """
 module: junos_lldp
 version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
-short_description: Manage LLDP configuration on Juniper JUNOS network devices
+short_description: (deprecated) Manage LLDP configuration on Juniper JUNOS network
+  devices
 description:
 - This module provides declarative management of LLDP service on Juniper JUNOS network
   devices.
@@ -63,6 +64,7 @@ notes:
 - This module also works with C(local) connections for legacy playbooks.
 extends_documentation_fragment:
 - junipernetworks.junos.junos
+
 """
 
 EXAMPLES = """

--- a/plugins/modules/junos_lldp_global.py
+++ b/plugins/modules/junos_lldp_global.py
@@ -32,7 +32,6 @@ __metaclass__ = type
 
 
 DOCUMENTATION = """
----
 module: junos_lldp_global
 short_description: Link layer discovery protocol (LLDP) JUNOS resource module
 version_added: "1.0.0"
@@ -85,6 +84,7 @@ notes:
   being managed.
 - Tested against vSRX JUNOS version 18.4R1.
 - This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
+
 """
 EXAMPLES = """
 # Using merged
@@ -123,7 +123,7 @@ EXAMPLES = """
     config:
       address: 20.2.2.2
       hold_multiplier: 30
-      enabled: False
+      enabled: false
     state: replaced
 
 # After state:

--- a/plugins/modules/junos_lldp_global.py
+++ b/plugins/modules/junos_lldp_global.py
@@ -93,7 +93,7 @@ EXAMPLES = """
 # user@junos01# # show protocols lldp
 #
 - name: Merge provided configuration with device configuration
-  junos_lldp_global:
+  junipernetworks.junos.junos_lldp_global:
     config:
       interval: 10000
       address: 10.1.1.1
@@ -119,7 +119,7 @@ EXAMPLES = """
 # hold-multiplier 10;
 
 - name: Replace provided configuration with device configuration
-  junos_lldp_global:
+  junipernetworks.junos.junos_lldp_global:
     config:
       address: 20.2.2.2
       hold_multiplier: 30
@@ -141,7 +141,7 @@ EXAMPLES = """
 # hold-multiplier 30;
 
 - name: Delete lldp configuration (this will by default remove all lldp configuration)
-  junos_lldp_global:
+  junipernetworks.junos.junos_lldp_global:
     state: deleted
 
 # After state:

--- a/plugins/modules/junos_lldp_global.py
+++ b/plugins/modules/junos_lldp_global.py
@@ -30,12 +30,12 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---
 module: junos_lldp_global
 short_description: Link layer discovery protocol (LLDP) JUNOS resource module
+version_added: "1.0.0"
 description:
 - This module manages link layer discovery protocol (LLDP) attributes on Juniper JUNOS
   devices.

--- a/plugins/modules/junos_lldp_interface.py
+++ b/plugins/modules/junos_lldp_interface.py
@@ -9,15 +9,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["deprecated"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_lldp_interface
+DOCUMENTATION = """
+---
+module: junos_lldp_interface
 author: Ganesh Nalawade (@ganeshrn)
+version_added: "1.0.0"
 short_description: Manage LLDP interfaces configuration on Juniper JUNOS network devices
 description:
 - This module provides declarative management of LLDP interfaces configuration on

--- a/plugins/modules/junos_lldp_interface.py
+++ b/plugins/modules/junos_lldp_interface.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
 module: junos_lldp_interface
 author: Ganesh Nalawade (@ganeshrn)
 version_added: "1.0.0"
-short_description: Manage LLDP interfaces configuration on Juniper JUNOS network devices
+short_description: (deprecated) Manage LLDP interfaces configuration on Juniper JUNOS network devices
 description:
 - This module provides declarative management of LLDP interfaces configuration on
   Juniper JUNOS network devices.
@@ -53,6 +53,7 @@ notes:
 - This module also works with C(local) connections for legacy playbooks.
 extends_documentation_fragment:
 - junipernetworks.junos.junos
+
 """
 
 EXAMPLES = """
@@ -80,13 +81,13 @@ EXAMPLES = """
   junipernetworks.junos.junos_lldp_interface:
     name: ge-0/0/5
     state: present
-    active: False
+    active: false
 
 - name: Activate LLDP on specific interfaces
   junipernetworks.junos.junos_lldp_interface:
     name: ge-0/0/5
     state: present
-    active: True
+    active: true
 """
 
 RETURN = """

--- a/plugins/modules/junos_lldp_interface.py
+++ b/plugins/modules/junos_lldp_interface.py
@@ -61,33 +61,33 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Configure LLDP on specific interfaces
-  junos_lldp_interface:
+  junipernetworks.junos.junos_lldp_interface:
     name: ge-0/0/5
     state: present
 
 - name: Disable LLDP on specific interfaces
-  junos_lldp_interface:
+  junipernetworks.junos.junos_lldp_interface:
     name: ge-0/0/5
     state: disabled
 
 - name: Enable LLDP on specific interfaces
-  junos_lldp_interface:
+  junipernetworks.junos.junos_lldp_interface:
     name: ge-0/0/5
     state: enabled
 
 - name: Delete LLDP configuration on specific interfaces
-  junos_lldp_interface:
+  junipernetworks.junos.junos_lldp_interface:
     name: ge-0/0/5
     state: present
 
 - name: Deactivate LLDP on specific interfaces
-  junos_lldp_interface:
+  junipernetworks.junos.junos_lldp_interface:
     name: ge-0/0/5
     state: present
     active: False
 
 - name: Activate LLDP on specific interfaces
-  junos_lldp_interface:
+  junipernetworks.junos.junos_lldp_interface:
     name: ge-0/0/5
     state: present
     active: True

--- a/plugins/modules/junos_lldp_interfaces.py
+++ b/plugins/modules/junos_lldp_interfaces.py
@@ -66,6 +66,7 @@ options:
     - deleted
     - gathered
     default: merged
+
 """
 EXAMPLES = """
 # Using merged
@@ -78,9 +79,9 @@ EXAMPLES = """
 - name: Merge provided configuration with device configuration
   junipernetworks.junos.junos_lldp_interfaces:
     config:
-      - name: ge-0/0/1
-      - name: ge-0/0/2
-        enabled: False
+    - name: ge-0/0/1
+    - name: ge-0/0/2
+      enabled: false
     state: merged
 
 # After state:
@@ -107,10 +108,10 @@ EXAMPLES = """
 - name: Replace provided configuration with device configuration
   junipernetworks.junos.junos_lldp_interfaces:
     config:
-      - name: ge-0/0/2
-        disable: False
-      - name: ge-0/0/3
-        enabled: False
+    - name: ge-0/0/2
+      disable: false
+    - name: ge-0/0/3
+      enabled: false
     state: replaced
 
 # After state:
@@ -138,8 +139,8 @@ EXAMPLES = """
 - name: Override provided configuration with device configuration
   junipernetworks.junos.junos_lldp_interfaces:
     config:
-      - name: ge-0/0/2
-        enabled: False
+    - name: ge-0/0/2
+      enabled: false
     state: overridden
 
 # After state:

--- a/plugins/modules/junos_lldp_interfaces.py
+++ b/plugins/modules/junos_lldp_interfaces.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---

--- a/plugins/modules/junos_lldp_interfaces.py
+++ b/plugins/modules/junos_lldp_interfaces.py
@@ -30,15 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_lldp_interfaces
-short_description: Manage link layer discovery protocol (LLDP) attributes of interfaces
-  on Juniper JUNOS devices
+DOCUMENTATION = """
+---
+module: junos_lldp_interfaces
+version_added: "1.0.0"
+short_description: Link layer discovery protocol (LLDP) interfaces Junos resource module
 description:
 - This module manages link layer discovery protocol (LLDP) attributes of interfaces
   on Juniper JUNOS devices.
@@ -67,6 +65,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
 """
 EXAMPLES = """

--- a/plugins/modules/junos_lldp_interfaces.py
+++ b/plugins/modules/junos_lldp_interfaces.py
@@ -77,7 +77,7 @@ EXAMPLES = """
 # advertisement-interval 10000;
 
 - name: Merge provided configuration with device configuration
-  junos_lldp_interfaces:
+  junipernetworks.junos.junos_lldp_interfaces:
     config:
       - name: ge-0/0/1
       - name: ge-0/0/2
@@ -106,7 +106,7 @@ EXAMPLES = """
 # }
 
 - name: Replace provided configuration with device configuration
-  junos_lldp_interfaces:
+  junipernetworks.junos.junos_lldp_interfaces:
     config:
       - name: ge-0/0/2
         disable: False
@@ -137,7 +137,7 @@ EXAMPLES = """
 # }
 
 - name: Override provided configuration with device configuration
-  junos_lldp_interfaces:
+  junipernetworks.junos.junos_lldp_interfaces:
     config:
       - name: ge-0/0/2
         enabled: False
@@ -164,7 +164,7 @@ EXAMPLES = """
 #     disable;
 # }
 - name: Delete lldp interface configuration (this will not delete other lldp configuration)
-  junos_lldp_interfaces:
+  junipernetworks.junos.junos_lldp_interfaces:
     config:
     - name: ge-0/0/1
     - name: ge-0/0/3

--- a/plugins/modules/junos_logging.py
+++ b/plugins/modules/junos_logging.py
@@ -84,31 +84,31 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: configure console logging
-  junos_logging:
+  junipernetworks.junos.junos_logging:
     dest: console
     facility: any
     level: critical
 
 - name: remove console logging configuration
-  junos_logging:
+  junipernetworks.junos.junos_logging:
     dest: console
     state: absent
 
 - name: configure file logging
-  junos_logging:
+  junipernetworks.junos.junos_logging:
     dest: file
     name: test
     facility: pfe
     level: error
 
 - name: configure logging parameter
-  junos_logging:
+  junipernetworks.junos.junos_logging:
     files: 30
     size: 65536
     rotate_frequency: 10
 
 - name: Configure file logging using aggregate
-  junos_logging:
+  junipernetworks.junos.junos_logging:
     dest: file
     aggregate:
     - name: test-1
@@ -120,7 +120,7 @@ EXAMPLES = """
     active: True
 
 - name: Delete file logging using aggregate
-  junos_logging:
+  junipernetworks.junos.junos_logging:
     aggregate:
     - { dest: file, name: test-1,  facility: pfe, level: critical }
     - { dest: file, name: test-2,  facility: kernel, level: emergency }

--- a/plugins/modules/junos_logging.py
+++ b/plugins/modules/junos_logging.py
@@ -113,13 +113,13 @@ EXAMPLES = """
     - name: test-2
       facility: kernel
       level: emergency
-    active: True
+    active: true
 
 - name: Delete file logging using aggregate
   junipernetworks.junos.junos_logging:
     aggregate:
-    - { dest: file, name: test-1,  facility: pfe, level: critical }
-    - { dest: file, name: test-2,  facility: kernel, level: emergency }
+    - {dest: file, name: test-1, facility: pfe, level: critical}
+    - {dest: file, name: test-2, facility: kernel, level: emergency}
     state: absent
 """
 

--- a/plugins/modules/junos_logging.py
+++ b/plugins/modules/junos_logging.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_logging
+DOCUMENTATION = """
+---
+module: junos_logging
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage logging on network devices
 description:

--- a/plugins/modules/junos_netconf.py
+++ b/plugins/modules/junos_netconf.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_netconf
+DOCUMENTATION = """
+---
+module: junos_netconf
+version_added: "1.0.0"
 author: Peter Sprygada (@privateip)
 short_description: Configures the Junos Netconf system service
 description:

--- a/plugins/modules/junos_netconf.py
+++ b/plugins/modules/junos_netconf.py
@@ -59,12 +59,12 @@ notes:
 
 EXAMPLES = """
 - name: enable netconf service on port 830
-  junos_netconf:
+  junipernetworks.junos.junos_netconf:
     listens_on: 830
     state: present
 
 - name: disable netconf service
-  junos_netconf:
+  junipernetworks.junos.junos_netconf:
     state: absent
 """
 

--- a/plugins/modules/junos_ospf.py
+++ b/plugins/modules/junos_ospf.py
@@ -219,7 +219,7 @@ EXAMPLES = """
 # admin# show protocols ospf
 
 - name: Merge Junos OSPF config
-  junos_ospf:
+  junipernetworks.junos.junos_ospf:
     config:
       - router_id: 10.200.16.75
         reference_bandwidth: 10g

--- a/plugins/modules/junos_ospf.py
+++ b/plugins/modules/junos_ospf.py
@@ -32,20 +32,19 @@ __metaclass__ = type
 
 
 DOCUMENTATION = """
----
 module: junos_ospf
-version_added: "1.0.0"
-short_description: Junos OSPFv2 resource module.
+short_description: OSPF resource module
 description:
-  - This module manages global OSPFv2 configuration on devices running Juniper JUNOS.
+- This module manages global OSPFv2 configuration on devices running Juniper JUNOS.
+version_added: 1.0.0
 author: Daniel Mellado (@dmellado)
 requirements:
-  - ncclient (>=v0.6.4)
-  - xmltodict (>=0.12.0)
+- ncclient (>=v0.6.4)
+- xmltodict (>=0.12.0)
 notes:
-  - This module requires the netconf system service be enabled on the device being managed.
-  - This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
-  - Tested against JunOS v18.4R1
+- This module requires the netconf system service be enabled on the device being managed.
+- This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
+- Tested against JunOS v18.4R1
 options:
   config:
     description: A list of OSPF process configuration.
@@ -54,40 +53,40 @@ options:
     suboptions:
       router_id:
         description:
-          - The OSPF router id.
+        - The OSPF router id.
         type: str
-        required: True
+        required: true
       areas:
         description:
-          - A list of OSPF areas' configuration.
+        - A list of OSPF areas' configuration.
         type: list
         elements: dict
         suboptions:
           area_id:
             description:
-              - The Area ID as an integer or IP Address.
+            - The Area ID as an integer or IP Address.
             type: str
-            required: True
+            required: true
           area_range:
             description:
-              - Configure an address range for the area.
+            - Configure an address range for the area.
             type: str
           stub:
             description:
-              - Settings for configuring the area as a stub.
+            - Settings for configuring the area as a stub.
             type: dict
             suboptions:
               default_metric:
                 description:
-                  - Metric for the default route in this area.
+                - Metric for the default route in this area.
                 type: int
               set:
                 description:
-                  - Configure the area as a stub.
+                - Configure the area as a stub.
                 type: bool
           interfaces:
             description:
-              - List of interfaces in this area.
+            - List of interfaces in this area.
             type: list
             elements: dict
             suboptions:
@@ -96,7 +95,7 @@ options:
                 suboptions:
                   type:
                     description:
-                      - Type of authentication to use.
+                    - Type of authentication to use.
                     type: dict
               bandwidth_based_metrics:
                 type: list
@@ -104,28 +103,28 @@ options:
                 suboptions:
                   bandwidth:
                     description:
-                      - BW to apply metric to.
+                    - BW to apply metric to.
                     type: str
-                    choices: ['1g', '10g']
+                    choices: [1g, 10g]
                   metric:
                     description:
                     type: int
               name:
                 description:
-                  - Name of the interface.
+                - Name of the interface.
                 type: str
-                required: True
+                required: true
               priority:
                 description:
-                  - Priority for the interface.
+                - Priority for the interface.
                 type: int
               metric:
                 description:
-                  - Metric applied to the interface.
+                - Metric applied to the interface.
                 type: int
               flood_reduction:
                 description:
-                  - Enable flood reduction.
+                - Enable flood reduction.
                 type: bool
               passive:
                 type: bool
@@ -134,72 +133,72 @@ options:
                 suboptions:
                   dead_interval:
                     description:
-                      - Dead interval (seconds).
+                    - Dead interval (seconds).
                     type: int
                   hello_interval:
                     description:
-                      - Hello interval (seconds).
+                    - Hello interval (seconds).
                     type: int
                   poll_interval:
                     description:
-                      - Poll interval (seconds).
+                    - Poll interval (seconds).
                     type: int
                   retransmit_interval:
                     description:
-                      - Retransmit interval (seconds).
+                    - Retransmit interval (seconds).
                     type: int
                   transit_delay:
                     description:
-                      - Transit delay (seconds).
+                    - Transit delay (seconds).
                     type: int
       external_preference:
         description:
-          - Preference of external routes.
+        - Preference of external routes.
         type: int
       overload:
         type: dict
         suboptions:
           timeout:
             description:
-              - Time after which overload mode is reset (seconds).
+            - Time after which overload mode is reset (seconds).
             type: int
       preference:
         description:
-          - Preference of internal routes.
+        - Preference of internal routes.
         type: int
       prefix_export_limit:
         description:
-          - Maximum number of external prefixes that can be exported.
+        - Maximum number of external prefixes that can be exported.
         type: int
       reference_bandwidth:
         description:
-          - Bandwidth for calculating metric defaults.
+        - Bandwidth for calculating metric defaults.
         type: str
-        choices: ['1g', '10g']
+        choices: [1g, 10g]
       rfc1583compatibility:
         description:
-          - Set RFC1583 compatibility
+        - Set RFC1583 compatibility
         type: bool
       spf_options:
         description:
-          - Configure options for SPF.
+        - Configure options for SPF.
         type: dict
         suboptions:
           delay:
             description:
-              - Time to wait before running an SPF (seconds).
+            - Time to wait before running an SPF (seconds).
             type: int
           holddown:
             description:
-              - Time to hold down before running an SPF (seconds).
+            - Time to hold down before running an SPF (seconds).
             type: int
           rapid_runs:
             description:
-              - Number of maximum rapid SPF runs before holddown (seconds).
+            - Number of maximum rapid SPF runs before holddown (seconds).
             type: int
   state:
     description:
-      - The state the configuration should be left in.
+    - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -208,6 +207,7 @@ options:
     - deleted
     - gathered
     default: merged
+
 """
 EXAMPLES = """
 # Using merged
@@ -220,31 +220,31 @@ EXAMPLES = """
 - name: Merge Junos OSPF config
   junipernetworks.junos.junos_ospf:
     config:
-      - router_id: 10.200.16.75
-        reference_bandwidth: 10g
-        areas:
-          - area_id: 0.0.0.100
-            area_range: 10.200.16.0/24
-            stub:
-              default_metric: 100
-              set: true
-            interfaces:
-              - name: so-0/0/0.0
-                priority: 3
-                metric: 5
-                flood_reduction: false
-                passive: true
-                bandwidth_based_metrics:
-                  - bandwidth: 1g
-                    metric: 5
-                  - bandwidth: 10g
-                    metric: 40
-                timers:
-                  dead_interval: 4
-                  hello_interval: 2
-                  poll_interval: 2
-                  retransmit_interval: 2
-        rfc1583compatibility: false
+    - router_id: 10.200.16.75
+      reference_bandwidth: 10g
+      areas:
+      - area_id: 0.0.0.100
+        area_range: 10.200.16.0/24
+        stub:
+          default_metric: 100
+          set: true
+        interfaces:
+        - name: so-0/0/0.0
+          priority: 3
+          metric: 5
+          flood_reduction: false
+          passive: true
+          bandwidth_based_metrics:
+          - bandwidth: 1g
+            metric: 5
+          - bandwidth: 10g
+            metric: 40
+          timers:
+            dead_interval: 4
+            hello_interval: 2
+            poll_interval: 2
+            retransmit_interval: 2
+      rfc1583compatibility: false
     state: merged
 
 # After state

--- a/plugins/modules/junos_ospf.py
+++ b/plugins/modules/junos_ospf.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---

--- a/plugins/modules/junos_package.py
+++ b/plugins/modules/junos_package.py
@@ -113,16 +113,16 @@ EXAMPLES = """
 # the examples for brevity
 
 - name: install local package on remote device
-  junos_package:
+  junipernetworks.junos.junos_package:
     src: junos-vsrx-12.1X46-D10.2-domestic.tgz
 
 - name: install local package on remote device without rebooting
-  junos_package:
+  junipernetworks.junos.junos_package:
     src: junos-vsrx-12.1X46-D10.2-domestic.tgz
     reboot: no
 
 - name: install local package on remote device with jumpost
-  junos_package:
+  junipernetworks.junos.junos_package:
     src: junos-vsrx-12.1X46-D10.2-domestic.tgz
     ssh_config: /home/user/customsshconfig
 """

--- a/plugins/modules/junos_package.py
+++ b/plugins/modules/junos_package.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_package
+DOCUMENTATION = """
+---
+module: junos_package
+version_added: "1.0.0"
 author: Peter Sprygada (@privateip)
 short_description: Installs packages on remote devices running Junos
 description:

--- a/plugins/modules/junos_package.py
+++ b/plugins/modules/junos_package.py
@@ -42,27 +42,27 @@ options:
       updated package has been installed. If disabled or the remote package does not
       need to be changed, the device will not be started.
     type: bool
-    default: 'yes'
+    default: yes
   no_copy:
     description:
     - The I(no_copy) argument is responsible for instructing the remote device on
       where to install the package from.  When enabled, the package is transferred
       to the remote device prior to installing.
     type: bool
-    default: 'no'
+    default: no
   validate:
     description:
     - The I(validate) argument is responsible for instructing the remote device to
       skip checking the current device configuration compatibility with the package
       being installed. When set to false validation is not performed.
     type: bool
-    default: 'yes'
+    default: yes
   force:
     description:
     - The I(force) argument instructs the module to bypass the package version check
       and install the packaged identified in I(src) on the remote device.
     type: bool
-    default: 'no'
+    default: no
   force_host:
     description:
     - The I(force_host) argument controls the way software package or bundle is added

--- a/plugins/modules/junos_ping.py
+++ b/plugins/modules/junos_ping.py
@@ -8,13 +8,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
 
-DOCUMENTATION = """module: junos_ping
+DOCUMENTATION = """
+---
+module: junos_ping
+version_added: "1.0.0"
 short_description: Tests reachability using ping from devices running Juniper JUNOS
 description:
 - Tests reachability using ping from devices running Juniper JUNOS to a remote destination.

--- a/plugins/modules/junos_ping.py
+++ b/plugins/modules/junos_ping.py
@@ -70,23 +70,23 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Test reachability to 10.10.10.10
-  junos_ping:
+  junipernetworks.junos.junos_ping:
     dest: 10.10.10.10
 
 - name: Test reachability to 10.20.20.20 using source and size set
-  junos_ping:
+  junipernetworks.junos.junos_ping:
     dest: 10.20.20.20
     size: 1024
     ttl: 128
 
 - name: Test unreachability to 10.30.30.30 using interval
-  junos_ping:
+  junipernetworks.junos.junos_ping:
     dest: 10.30.30.30
     interval: 3
     state: absent
 
 - name: Test reachability to 10.40.40.40 setting count and interface
-  junos_ping:
+  junipernetworks.junos.junos_ping:
     dest: 10.40.40.40
     interface: fxp0
     count: 20

--- a/plugins/modules/junos_rpc.py
+++ b/plugins/modules/junos_rpc.py
@@ -59,18 +59,18 @@ notes:
 
 EXAMPLES = """
 - name: collect interface information using rpc
-  junos_rpc:
+  junipernetworks.junos.junos_rpc:
     rpc: get-interface-information
     args:
       interface-name: em0
       media: True
 
 - name: get system information
-  junos_rpc:
+  junipernetworks.junos.junos_rpc:
     rpc: get-system-information
 
 - name: load configuration
-  junos_rpc:
+  junipernetworks.junos.junos_rpc:
     rpc: load-configuration
     attrs:
       action: override

--- a/plugins/modules/junos_rpc.py
+++ b/plugins/modules/junos_rpc.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_rpc
+DOCUMENTATION = """
+---
+module: junos_rpc
+version_added: "1.0.0"
 author: Peter Sprygada (@privateip)
 short_description: Runs an arbitrary RPC over NetConf on an Juniper JUNOS device
 description:

--- a/plugins/modules/junos_rpc.py
+++ b/plugins/modules/junos_rpc.py
@@ -13,6 +13,7 @@ DOCUMENTATION = """
 ---
 module: junos_rpc
 version_added: "1.0.0"
+module: junos_rpc
 author: Peter Sprygada (@privateip)
 short_description: Runs an arbitrary RPC over NetConf on an Juniper JUNOS device
 description:
@@ -59,7 +60,7 @@ EXAMPLES = """
     rpc: get-interface-information
     args:
       interface-name: em0
-      media: True
+      media: true
 
 - name: get system information
   junipernetworks.junos.junos_rpc:

--- a/plugins/modules/junos_scp.py
+++ b/plugins/modules/junos_scp.py
@@ -74,21 +74,21 @@ EXAMPLES = """
 # the required set of connection arguments have been purposely left off
 # the examples for brevity
 - name: upload local file to home directory on remote device
-  junos_scp:
+  junipernetworks.junos.junos_scp:
     src: test.tgz
 
 - name: upload local file to tmp directory on remote device
-  junos_scp:
+  junipernetworks.junos.junos_scp:
     src: test.tgz
     dest: /tmp/
 
 - name: download file from remote device
-  junos_scp:
+  junipernetworks.junos.junos_scp:
     src: test.tgz
     remote_src: true
 
 - name: ssh config file path for jumphost config
-  junos_scp:
+  junipernetworks.junos.junos_scp:
     src: test.tgz
     remote_src: true
     ssh_config: /home/user/customsshconfig

--- a/plugins/modules/junos_scp.py
+++ b/plugins/modules/junos_scp.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_scp
+DOCUMENTATION = """
+---
+module: junos_scp
+version_added: "1.0.0"
 author: Christian Giese (@GIC-de)
 short_description: Transfer files from or to remote devices running Junos
 description:

--- a/plugins/modules/junos_scp.py
+++ b/plugins/modules/junos_scp.py
@@ -33,14 +33,14 @@ options:
     description:
     - The C(recursive) argument enables recursive transfer of files and directories.
     type: bool
-    default: 'no'
+    default: no
   remote_src:
     description:
     - The C(remote_src) argument enables the download of files (I(scp get)) from the
       remote device. The default behavior is to upload files (I(scp put)) to the remote
       device.
     type: bool
-    default: 'no'
+    default: no
   ssh_private_key_file:
     description:
     - The C(ssh_private_key_file) argument is path to the SSH private key file. This

--- a/plugins/modules/junos_static_route.py
+++ b/plugins/modules/junos_static_route.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
 module: junos_static_route
 version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
-short_description: Manage static IP routes on Juniper JUNOS network devices
+short_description: (deprecated) Manage static IP routes on Juniper JUNOS network devices
 description:
 - This module provides declarative management of static IP routes on Juniper JUNOS
   network devices.
@@ -69,6 +69,7 @@ notes:
 - This module also works with C(local) connections for legacy playbooks.
 extends_documentation_fragment:
 - junipernetworks.junos.junos
+
 """
 
 EXAMPLES = """
@@ -94,7 +95,7 @@ EXAMPLES = """
     qualified_next_hop: 10.0.0.2
     qualified_preference: 3
     state: present
-    active: False
+    active: false
 
 - name: activate static route configuration
   junipernetworks.junos.junos_static_route:
@@ -104,13 +105,13 @@ EXAMPLES = """
     qualified_next_hop: 10.0.0.2
     qualified_preference: 3
     state: present
-    active: True
+    active: true
 
 - name: Configure static route using aggregate
   junipernetworks.junos.junos_static_route:
     aggregate:
-    - { address: 4.4.4.0/24, next_hop: 3.3.3.3, qualified_next_hop: 5.5.5.5, qualified_preference: 30 }
-    - { address: 5.5.5.0/24, next_hop: 6.6.6.6, qualified_next_hop: 7.7.7.7, qualified_preference: 12 }
+    - {address: 4.4.4.0/24, next_hop: 3.3.3.3, qualified_next_hop: 5.5.5.5, qualified_preference: 30}
+    - {address: 5.5.5.0/24, next_hop: 6.6.6.6, qualified_next_hop: 7.7.7.7, qualified_preference: 12}
     preference: 10
 
 - name: Delete static route using aggregate

--- a/plugins/modules/junos_static_route.py
+++ b/plugins/modules/junos_static_route.py
@@ -77,7 +77,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: configure static route
-  junos_static_route:
+  junipernetworks.junos.junos_static_route:
     address: 192.168.2.0/24
     next_hop: 10.0.0.1
     preference: 10
@@ -86,12 +86,12 @@ EXAMPLES = """
     state: present
 
 - name: delete static route
-  junos_static_route:
+  junipernetworks.junos.junos_static_route:
     address: 192.168.2.0/24
     state: absent
 
 - name: deactivate static route configuration
-  junos_static_route:
+  junipernetworks.junos.junos_static_route:
     address: 192.168.2.0/24
     next_hop: 10.0.0.1
     preference: 10
@@ -101,7 +101,7 @@ EXAMPLES = """
     active: False
 
 - name: activate static route configuration
-  junos_static_route:
+  junipernetworks.junos.junos_static_route:
     address: 192.168.2.0/24
     next_hop: 10.0.0.1
     preference: 10
@@ -111,14 +111,14 @@ EXAMPLES = """
     active: True
 
 - name: Configure static route using aggregate
-  junos_static_route:
+  junipernetworks.junos.junos_static_route:
     aggregate:
     - { address: 4.4.4.0/24, next_hop: 3.3.3.3, qualified_next_hop: 5.5.5.5, qualified_preference: 30 }
     - { address: 5.5.5.0/24, next_hop: 6.6.6.6, qualified_next_hop: 7.7.7.7, qualified_preference: 12 }
     preference: 10
 
 - name: Delete static route using aggregate
-  junos_static_route:
+  junipernetworks.junos.junos_static_route:
     aggregate:
     - address: 4.4.4.0/24
     - address: 5.5.5.0/24

--- a/plugins/modules/junos_static_route.py
+++ b/plugins/modules/junos_static_route.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["deprecated"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_static_route
+DOCUMENTATION = """
+---
+module: junos_static_route
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage static IP routes on Juniper JUNOS network devices
 description:

--- a/plugins/modules/junos_static_routes.py
+++ b/plugins/modules/junos_static_routes.py
@@ -29,14 +29,10 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """module: junos_static_routes
-short_description: Manage static routes on Juniper JUNOS devices
+short_description: Static routes Junos resource module
 description: This module provides declarative management of static routes on Juniper
   JUNOS devices
 author: Daniel Mellado (@dmellado)
@@ -104,6 +100,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
 """
 

--- a/plugins/modules/junos_static_routes.py
+++ b/plugins/modules/junos_static_routes.py
@@ -104,10 +104,10 @@ options:
     - deleted
     - gathered
     default: merged
+
 """
 
 EXAMPLES = """
----
 # Using deleted
 
 # Before state
@@ -123,12 +123,12 @@ EXAMPLES = """
 - name: Delete provided configuration (default operation is merge)
   junipernetworks.junos.junos_static_routes:
     config:
-      - address_families:
-        - afi: 'ipv4'
-          routes:
-            - dest: 10.200.16.75/24
-              next_hop:
-                - forward_router_address: 10.200.16.2
+    - address_families:
+      - afi: ipv4
+        routes:
+        - dest: 10.200.16.75/24
+          next_hop:
+          - forward_router_address: 10.200.16.2
     state: deleted
 
 # After state:
@@ -154,12 +154,12 @@ EXAMPLES = """
 - name: Merge provided configuration with device configuration (default operation is merge)
   junipernetworks.junos.junos_static_routes:
     config:
-      - address_families:
-          - afi: 'ipv4'
-            routes:
-              - dest: 10.200.16.75/24
-                next_hop:
-                  - forward_router_address: 10.200.16.2
+    - address_families:
+      - afi: ipv4
+        routes:
+        - dest: 10.200.16.75/24
+          next_hop:
+          - forward_router_address: 10.200.16.2
     state: merged
 
 # After state:
@@ -186,12 +186,12 @@ EXAMPLES = """
 - name: Override provided configuration with device configuration (default operation is merge)
   junipernetworks.junos.junos_static_routes:
     config:
-      - address_families:
-        - afi: 'ipv4'
-          routes:
-            - dest: 10.200.16.75/24
-              next_hop:
-                - forward_router_address: 10.200.16.2
+    - address_families:
+      - afi: ipv4
+        routes:
+        - dest: 10.200.16.75/24
+          next_hop:
+          - forward_router_address: 10.200.16.2
     state: overridden
 
 # After state:
@@ -216,12 +216,12 @@ EXAMPLES = """
 - name: Replace provided configuration with device configuration (default operation is merge)
   junipernetworks.junos.junos_static_routes:
     config:
-      - address_families:
-        - afi: 'ipv4'
-          routes:
-            - dest: 192.168.47.0/24
-              next_hop:
-                - forward_router_address: 10.200.16.2
+    - address_families:
+      - afi: ipv4
+        routes:
+        - dest: 192.168.47.0/24
+          next_hop:
+          - forward_router_address: 10.200.16.2
     state: replaced
 
 # After state:

--- a/plugins/modules/junos_static_routes.py
+++ b/plugins/modules/junos_static_routes.py
@@ -119,7 +119,7 @@ EXAMPLES = """
 # }
 
 - name: Delete provided configuration (default operation is merge)
-  junos_static_routes:
+  junipernetworks.junos.junos_static_routes:
     config:
       - address_families:
         - afi: 'ipv4'
@@ -150,7 +150,7 @@ EXAMPLES = """
 # }
 
 - name: Merge provided configuration with device configuration (default operation is merge)
-  junos_static_routes:
+  junipernetworks.junos.junos_static_routes:
     config:
       - address_families:
           - afi: 'ipv4'
@@ -182,7 +182,7 @@ EXAMPLES = """
 # }
 
 - name: Override provided configuration with device configuration (default operation is merge)
-  junos_static_routes:
+  junipernetworks.junos.junos_static_routes:
     config:
       - address_families:
         - afi: 'ipv4'
@@ -212,7 +212,7 @@ EXAMPLES = """
 # }
 
 - name: Replace provided configuration with device configuration (default operation is merge)
-  junos_static_routes:
+  junipernetworks.junos.junos_static_routes:
     config:
       - address_families:
         - afi: 'ipv4'

--- a/plugins/modules/junos_static_routes.py
+++ b/plugins/modules/junos_static_routes.py
@@ -29,9 +29,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_static_routes
+DOCUMENTATION = """
+---
+module: junos_static_routes
+version_added: "1.0.0"
 short_description: Static routes Junos resource module
 description: This module provides declarative management of static routes on Juniper
   JUNOS devices

--- a/plugins/modules/junos_system.py
+++ b/plugins/modules/junos_system.py
@@ -69,7 +69,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: configure hostname and domain name
-  junos_system:
+  junipernetworks.junos.junos_system:
     hostname: junos01
     domain_name: test.example.com
     domain-search:
@@ -78,11 +78,11 @@ EXAMPLES = """
       - juniper.net
 
 - name: remove configuration
-  junos_system:
+  junipernetworks.junos.junos_system:
     state: absent
 
 - name: configure name servers
-  junos_system:
+  junipernetworks.junos.junos_system:
     name_servers:
       - 8.8.8.8
       - 8.8.4.4

--- a/plugins/modules/junos_system.py
+++ b/plugins/modules/junos_system.py
@@ -69,9 +69,9 @@ EXAMPLES = """
     hostname: junos01
     domain_name: test.example.com
     domain-search:
-      - ansible.com
-      - redhat.com
-      - juniper.net
+    - ansible.com
+    - redhat.com
+    - juniper.net
 
 - name: remove configuration
   junipernetworks.junos.junos_system:
@@ -80,8 +80,8 @@ EXAMPLES = """
 - name: configure name servers
   junipernetworks.junos.junos_system:
     name_servers:
-      - 8.8.8.8
-      - 8.8.4.4
+    - 8.8.8.8
+    - 8.8.4.4
 """
 
 RETURN = """

--- a/plugins/modules/junos_system.py
+++ b/plugins/modules/junos_system.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_system
+DOCUMENTATION = """
+---
+module: junos_system
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage the system attributes on Juniper JUNOS devices
 description:

--- a/plugins/modules/junos_user.py
+++ b/plugins/modules/junos_user.py
@@ -63,7 +63,7 @@ options:
       absolute.  It will remove any previously configured users on the device with
       the exception of the current defined set of aggregate.
     type: bool
-    default: 'no'
+    default: no
   state:
     description:
     - The C(state) argument configures the state of the user definitions as it relates
@@ -78,7 +78,7 @@ options:
     description:
     - Specifies whether or not the configuration is active or deactivated
     type: bool
-    default: 'yes'
+    default: yes
 requirements:
 - ncclient (>=v0.5.2)
 notes:
@@ -91,41 +91,41 @@ notes:
 
 EXAMPLES = """
 - name: create new user account
-  junos_user:
+  junipernetworks.junos.junos_user:
     name: ansible
     role: super-user
     sshkey: "{{ lookup('file', '~/.ssh/ansible.pub') }}"
     state: present
 
 - name: remove a user account
-  junos_user:
+  junipernetworks.junos.junos_user:
     name: ansible
     state: absent
 
 - name: remove all user accounts except ansible
-  junos_user:
+  junipernetworks.junos.junos_user:
     aggregate:
     - name: ansible
     purge: yes
 
 - name: set user password
-  junos_user:
+  junipernetworks.junos.junos_user:
     name: ansible
     role: super-user
     encrypted_password: "{{ 'my-password' | password_hash('sha512') }}"
     state: present
 
 - name: Create list of users
-  junos_user:
+  junipernetworks.junos.junos_user:
     aggregate:
-      - {name: test_user1, full_name: test_user2, role: operator, state: present}
-      - {name: test_user2, full_name: test_user2, role: read-only, state: present}
+    - {name: test_user1, full_name: test_user2, role: operator, state: present}
+    - {name: test_user2, full_name: test_user2, role: read-only, state: present}
 
 - name: Delete list of users
-  junos_user:
+  junipernetworks.junos.junos_user:
     aggregate:
-      - {name: test_user1, full_name: test_user2, role: operator, state: absent}
-      - {name: test_user2, full_name: test_user2, role: read-only, state: absent}
+    - {name: test_user1, full_name: test_user2, role: operator, state: absent}
+    - {name: test_user2, full_name: test_user2, role: read-only, state: absent}
 """
 
 RETURN = """

--- a/plugins/modules/junos_user.py
+++ b/plugins/modules/junos_user.py
@@ -9,14 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-
-DOCUMENTATION = """module: junos_user
+DOCUMENTATION = """
+---
+module: junos_user
+version_added: "1.0.0"
 author: Peter Sprygada (@privateip)
 short_description: Manage local user accounts on Juniper JUNOS devices
 description:

--- a/plugins/modules/junos_vlan.py
+++ b/plugins/modules/junos_vlan.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
 module: junos_vlan
 version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
-short_description: Manage VLANs on Juniper JUNOS network devices
+short_description: (deprecated) Manage VLANs on Juniper JUNOS network devices
 description:
 - This module provides declarative management of VLANs on Juniper JUNOS network devices.
 deprecated:
@@ -69,6 +69,7 @@ notes:
 - This module also works with C(local) connections for legacy playbooks.
 extends_documentation_fragment:
 - junipernetworks.junos.junos
+
 """
 
 EXAMPLES = """
@@ -92,25 +93,25 @@ EXAMPLES = """
   junipernetworks.junos.junos_vlan:
     name: test
     state: present
-    active: False
+    active: false
 
 - name: activate VLAN configuration
   junipernetworks.junos.junos_vlan:
     name: test
     state: present
-    active: True
+    active: true
 
 - name: Create vlan configuration using aggregate
   junipernetworks.junos.junos_vlan:
     aggregate:
-      - { vlan_id: 159, name: test_vlan_1, description: test vlan-1 }
-      - { vlan_id: 160, name: test_vlan_2, description: test vlan-2 }
+    - {vlan_id: 159, name: test_vlan_1, description: test vlan-1}
+    - {vlan_id: 160, name: test_vlan_2, description: test vlan-2}
 
 - name: Delete vlan configuration using aggregate
   junipernetworks.junos.junos_vlan:
     aggregate:
-      - { vlan_id: 159, name: test_vlan_1 }
-      - { vlan_id: 160, name: test_vlan_2 }
+    - {vlan_id: 159, name: test_vlan_1}
+    - {vlan_id: 160, name: test_vlan_2}
     state: absent
 """
 

--- a/plugins/modules/junos_vlan.py
+++ b/plugins/modules/junos_vlan.py
@@ -76,41 +76,41 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: configure VLAN ID and name
-  junos_vlan:
+  junipernetworks.junos.junos_vlan:
     name: test
     vlan_id: 20
 
 - name: Link to logical layer 3 interface
-  junos_vlan:
+  junipernetworks.junos.junos_vlan:
     name: test
     vlan_id: 20
     l3-interface: vlan.20
 
 - name: remove VLAN configuration
-  junos_vlan:
+  junipernetworks.junos.junos_vlan:
     name: test
     state: absent
 
 - name: deactive VLAN configuration
-  junos_vlan:
+  junipernetworks.junos.junos_vlan:
     name: test
     state: present
     active: False
 
 - name: activate VLAN configuration
-  junos_vlan:
+  junipernetworks.junos.junos_vlan:
     name: test
     state: present
     active: True
 
 - name: Create vlan configuration using aggregate
-  junos_vlan:
+  junipernetworks.junos.junos_vlan:
     aggregate:
       - { vlan_id: 159, name: test_vlan_1, description: test vlan-1 }
       - { vlan_id: 160, name: test_vlan_2, description: test vlan-2 }
 
 - name: Delete vlan configuration using aggregate
-  junos_vlan:
+  junipernetworks.junos.junos_vlan:
     aggregate:
       - { vlan_id: 159, name: test_vlan_1 }
       - { vlan_id: 160, name: test_vlan_2 }

--- a/plugins/modules/junos_vlan.py
+++ b/plugins/modules/junos_vlan.py
@@ -9,13 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["deprecated"],
-    "supported_by": "network",
-}
-
-DOCUMENTATION = """module: junos_vlan
+DOCUMENTATION = """
+---
+module: junos_vlan
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage VLANs on Juniper JUNOS network devices
 description:

--- a/plugins/modules/junos_vlans.py
+++ b/plugins/modules/junos_vlans.py
@@ -77,6 +77,7 @@ options:
     - deleted
     - gathered
     default: merged
+
 """
 
 EXAMPLES = """
@@ -97,137 +98,30 @@ EXAMPLES = """
 - name: Merge JUNOS vlan
   junipernetworks.junos.junos_vlans:
     config:
-      - name: vlan-1
-        vlan-id: 1
+    - name: vlan-1
+      vlan-id: 1
   state: merged
-
-# After State
-# -----------
-#
-# admin# show vlans
-# vlan-1 {
-#     vlan-id 1;
-# }
-# vlan-2 {
-#     vlan-id 2;
-# }
-# vlan-3 {
-#     vlan-id 3;
-# }
-
-
-# Using replaced
-################
-
-# Before State
-# ------------
-#
-# admin# show vlans
-# vlan-1 {
-#     vlan-id 1;
-# }
-# vlan-2 {
-#     vlan-id 2;
-# }
-# vlan-3 {
-#     vlan-id 3;
-# }
-
 - name: Replace JUNOS vlan
   junipernetworks.junos.junos_vlans:
     config:
-      - name: vlan-1
-        vlan-id: 10
-      - name: vlan-3
-        vlan-id: 30
+    - name: vlan-1
+      vlan-id: 10
+    - name: vlan-3
+      vlan-id: 30
   state: replaced
-
-# After State
-# -----------
-#
-# admin# show vlans
-# vlan-1 {
-#     vlan-id 10;
-# }
-# vlan-2 {
-#     vlan-id 2;
-# }
-# vlan-3 {
-#     vlan-id 30;
-# }
-
-
-# Using overridden
-##################
-
-# Before State
-# ------------
-#
-# admin# show vlans
-# vlan-1 {
-#     vlan-id 1;
-# }
-# vlan-2 {
-#     vlan-id 2;
-# }
-# vlan-3 {
-#     vlan-id 3;
-# }
-
 - name: Override JUNOS vlan
   junipernetworks.junos.junos_vlans:
     config:
-      - name: vlan-4
-        vlan-id: 100
-      - name: vlan-2
-        vlan-id: 200
+    - name: vlan-4
+      vlan-id: 100
+    - name: vlan-2
+      vlan-id: 200
   state: overridden
-
-# After State
-# -----------
-#
-# admin# show vlans
-# vlan-2 {
-#     vlan-id 200;
-# }
-# vlan-4 {
-#     vlan-id 100;
-# }
-
-
-#Using deleted
-##############
-
-# Before State
-# ------------
-#
-# admin# show vlans
-# vlan-1 {
-#     vlan-id 1;
-# }
-# vlan-2 {
-#     vlan-id 2;
-# }
-# vlan-3 {
-#     vlan-id 3;
-# }
-
 - name: Delete JUNOS vlan
   junipernetworks.junos.junos_vlans:
     config:
-      - name: vlan-1
+    - name: vlan-1
   state: deleted
-
-# After State
-# -----------
-#
-# admin# show vlans
-# vlan-2 {
-#     vlan-id 2;
-# }
-# vlan-3 {
-#     vlan-id 3;
-# }
 """
 
 RETURN = """

--- a/plugins/modules/junos_vlans.py
+++ b/plugins/modules/junos_vlans.py
@@ -30,23 +30,23 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_vlans
-short_description: Create and manage VLAN configurations on Junos OS
-description: This module creates and manages VLAN configurations on Junos OS.
-author: Daniel Mellado (@danielmellado)
+DOCUMENTATION = """
+---
+module: junos_vlans
+version_added: "1.0.0"
+short_description: Junos VLANs resource module.
+description:
+  - This module creates and manages VLAN configurations on Junos OS.
+author: Daniel Mellado (@dmellado)
 requirements:
-- ncclient (>=v0.6.4)
+  - ncclient (>=v0.6.4)
 notes:
-- This module requires the netconf system service be enabled on the remote device
-  being managed
-- Tested against Junos OS 18.4R1
-- This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
+  - This module requires the netconf system service be enabled on the remote device
+    being managed
+  - Tested against Junos OS 18.4R1
+  - This module works with connection C(netconf). See L(the Junos OS Platform Options,../network/user_guide/platform_junos.html).
 options:
   config:
     description: A dictionary of Vlan options
@@ -76,6 +76,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
 """
 

--- a/plugins/modules/junos_vlans.py
+++ b/plugins/modules/junos_vlans.py
@@ -96,7 +96,7 @@ EXAMPLES = """
 # }
 
 - name: Merge JUNOS vlan
-  junos_vlans:
+  junipernetworks.junos.junos_vlans:
     config:
       - name: vlan-1
         vlan-id: 1
@@ -135,7 +135,7 @@ EXAMPLES = """
 # }
 
 - name: Replace JUNOS vlan
-  junos_vlans:
+  junipernetworks.junos.junos_vlans:
     config:
       - name: vlan-1
         vlan-id: 10
@@ -176,7 +176,7 @@ EXAMPLES = """
 # }
 
 - name: Override JUNOS vlan
-  junos_vlans:
+  junipernetworks.junos.junos_vlans:
     config:
       - name: vlan-4
         vlan-id: 100
@@ -214,7 +214,7 @@ EXAMPLES = """
 # }
 
 - name: Delete JUNOS vlan
-  junos_vlans:
+  junipernetworks.junos.junos_vlans:
     config:
       - name: vlan-1
   state: deleted

--- a/plugins/modules/junos_vlans.py
+++ b/plugins/modules/junos_vlans.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """
 ---

--- a/plugins/modules/junos_vrf.py
+++ b/plugins/modules/junos_vrf.py
@@ -9,13 +9,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
-DOCUMENTATION = """module: junos_vrf
+DOCUMENTATION = """
+---
+module: junos_vrf
+version_added: "1.0.0"
 author: Ganesh Nalawade (@ganeshrn)
 short_description: Manage the VRF definitions on Juniper JUNOS devices
 description:

--- a/plugins/modules/junos_vrf.py
+++ b/plugins/modules/junos_vrf.py
@@ -86,8 +86,8 @@ EXAMPLES = """
     name: test-1
     description: test-vrf-1
     interfaces:
-      - ge-0/0/3
-      - ge-0/0/2
+    - ge-0/0/3
+    - ge-0/0/2
     rd: 192.0.2.1:10
     target: target:65514:113
     state: present
@@ -97,8 +97,8 @@ EXAMPLES = """
     name: test-1
     description: test-vrf-1
     interfaces:
-      - ge-0/0/3
-      - ge-0/0/2
+    - ge-0/0/3
+    - ge-0/0/2
     rd: 192.0.2.1:10
     target: target:65514:113
     state: absent
@@ -108,22 +108,22 @@ EXAMPLES = """
     name: test-1
     description: test-vrf-1
     interfaces:
-      - ge-0/0/3
-      - ge-0/0/2
+    - ge-0/0/3
+    - ge-0/0/2
     rd: 192.0.2.1:10
     target: target:65514:113
-    active: False
+    active: false
 
 - name: Activate vrf configuration
   junipernetworks.junos.junos_vrf:
     name: test-1
     description: test-vrf-1
     interfaces:
-      - ge-0/0/3
-      - ge-0/0/2
+    - ge-0/0/3
+    - ge-0/0/2
     rd: 192.0.2.1:10
     target: target:65514:113
-    active: True
+    active: true
 
 - name: Create vrf using aggregate
   junipernetworks.junos.junos_vrf:
@@ -131,15 +131,14 @@ EXAMPLES = """
     - name: test-1
       description: test-vrf-1
       interfaces:
-        - ge-0/0/3
-         - ge-0/0/2
+      - ge-0/0/3 - ge-0/0/2
       rd: 192.0.2.1:10
       target: target:65514:113
     - name: test-2
       description: test-vrf-2
       interfaces:
-        - ge-0/0/4
-        - ge-0/0/5
+      - ge-0/0/4
+      - ge-0/0/5
       rd: 192.0.2.2:10
       target: target:65515:114
   state: present

--- a/plugins/modules/junos_vrf.py
+++ b/plugins/modules/junos_vrf.py
@@ -85,7 +85,7 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 - name: Configure vrf configuration
-  junos_vrf:
+  junipernetworks.junos.junos_vrf:
     name: test-1
     description: test-vrf-1
     interfaces:
@@ -96,7 +96,7 @@ EXAMPLES = """
     state: present
 
 - name: Remove vrf configuration
-  junos_vrf:
+  junipernetworks.junos.junos_vrf:
     name: test-1
     description: test-vrf-1
     interfaces:
@@ -107,7 +107,7 @@ EXAMPLES = """
     state: absent
 
 - name: Deactivate vrf configuration
-  junos_vrf:
+  junipernetworks.junos.junos_vrf:
     name: test-1
     description: test-vrf-1
     interfaces:
@@ -118,7 +118,7 @@ EXAMPLES = """
     active: False
 
 - name: Activate vrf configuration
-  junos_vrf:
+  junipernetworks.junos.junos_vrf:
     name: test-1
     description: test-vrf-1
     interfaces:
@@ -129,7 +129,7 @@ EXAMPLES = """
     active: True
 
 - name: Create vrf using aggregate
-  junos_vrf:
+  junipernetworks.junos.junos_vrf:
     aggregate:
     - name: test-1
       description: test-vrf-1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ flake8
 mock
 pytest-xdist
 yamllint
+coverage==4.5.4

--- a/tests/integration/targets/junos_banner/tasks/main.yaml
+++ b/tests/integration/targets/junos_banner/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_banner/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_banner/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_command/tasks/main.yaml
+++ b/tests/integration/targets/junos_command/tasks/main.yaml
@@ -1,19 +1,10 @@
 ---
 - include: netconf_xml.yaml
-  tags:
-    - netconf
-    - xml
 
 - include: netconf_text.yaml
-  tags:
-    - netconf
-    - text
 
 - include: netconf_json.yaml
-  tags:
-    - netconf
-    - json
 
 - include: cli.yaml
   tags:
-    - cli
+    - network_cli

--- a/tests/integration/targets/junos_command/tasks/netconf_json.yaml
+++ b/tests/integration/targets/junos_command/tasks/netconf_json.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_command/tasks/netconf_text.yaml
+++ b/tests/integration/targets/junos_command/tasks/netconf_text.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_command/tasks/netconf_xml.yaml
+++ b/tests/integration/targets/junos_command/tasks/netconf_xml.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_config/tasks/main.yaml
+++ b/tests/integration/targets/junos_config/tasks/main.yaml
@@ -1,8 +1,6 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf
 
 - include: cli_config.yaml
   tags:
-    - cli_config
+    - network_cli

--- a/tests/integration/targets/junos_config/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_config/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_facts/tasks/main.yaml
+++ b/tests/integration/targets/junos_facts/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_facts/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_facts/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_interface/tasks/main.yaml
+++ b/tests/integration/targets/junos_interface/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_interface/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_interface/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_l2_interface/tasks/main.yaml
+++ b/tests/integration/targets/junos_l2_interface/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_l2_interface/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_l2_interface/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_first_found: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_l3_interface/tasks/main.yaml
+++ b/tests/integration/targets/junos_l3_interface/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_l3_interface/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_l3_interface/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_linkagg/tasks/main.yaml
+++ b/tests/integration/targets/junos_linkagg/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_linkagg/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_linkagg/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_lldp/tasks/main.yaml
+++ b/tests/integration/targets/junos_lldp/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_lldp/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_lldp/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_lldp_interface/tasks/main.yaml
+++ b/tests/integration/targets/junos_lldp_interface/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_lldp_interface/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_lldp_interface/tasks/netconf.yaml
@@ -17,9 +17,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_logging/tasks/main.yaml
+++ b/tests/integration/targets/junos_logging/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_logging/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_logging/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_netconf/tasks/cli.yaml
+++ b/tests/integration/targets/junos_netconf/tasks/cli.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - network_cli
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_netconf/tasks/main.yaml
+++ b/tests/integration/targets/junos_netconf/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: cli.yaml
-  tags:
-    - cli

--- a/tests/integration/targets/junos_rpc/tasks/main.yaml
+++ b/tests/integration/targets/junos_rpc/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_rpc/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_rpc/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_static_route/tasks/main.yaml
+++ b/tests/integration/targets/junos_static_route/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_static_route/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_static_route/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_system/tasks/main.yaml
+++ b/tests/integration/targets/junos_system/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_system/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_system/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_user/tasks/main.yaml
+++ b/tests/integration/targets/junos_user/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_user/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_user/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_vlan/tasks/main.yaml
+++ b/tests/integration/targets/junos_vlan/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_vlan/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_vlan/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local

--- a/tests/integration/targets/junos_vrf/tasks/main.yaml
+++ b/tests/integration/targets/junos_vrf/tasks/main.yaml
@@ -1,4 +1,2 @@
 ---
 - include: netconf.yaml
-  tags:
-    - netconf

--- a/tests/integration/targets/junos_vrf/tasks/netconf.yaml
+++ b/tests/integration/targets/junos_vrf/tasks/netconf.yaml
@@ -14,9 +14,13 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - netconf
 
 - name: run test case (connection=local)
   include: '{{ test_case_to_run }} ansible_connection=local'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags:
+    - local


### PR DESCRIPTION
## Update documenation and add state for junos_vlans

This commit adds gathered state for junos_vlans and updates the
documentation to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Rework tags for testing

This allows us to create 3 jobs now. network_cli, local, netconf.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>

## Update docs and add state for junos_lag_interfaces

This commit adds gathered state for junos_lag_interfaces and updates the
documentation to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Update docs and add state for junos_lldp_interfaces

This commit adds gathered state for junos_lldp_interfaces and updates the
documentation to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Update docs and add state for junos_interfaces

This commit adds gathered state for junos_interfaces and updates the
documentation to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Update documenation and add state for junos_acls

This commit adds gathered state for junos_acls and updates the
documentation to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Update docs and add state for junos_l3_interfaces

This commit adds gathered state for junos_l3_interfaces and updates the
documentation to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Update docs and add state for junos_static_routes

This commit adds gathered state for junos_static_routes and updates the
documentation to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Update docs and add state for junos_lacp_interfaces

This commit adds gathered state for junos_lacp_interfaces and updates the
documentation to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Update docs and add state for junos_lacp

This commit adds gathered state for junos_lacp and updates the
documentation to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Update docs and state for junos_acl_interfaces

This commit adds gathered state for junos_acl_interfaces and updates the
documentetion to the new resource modules versioning for collections.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Add FQCN to junos modules examples

This commit adds collection FQCN to all the examples shown on the
collection documentation.

## Add version_added and remove metadata

This commits adds the collection version added and removes
ANSIBLE_METADATA for every module on it.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Add Junos Module Doc

This commit adds the documentation generated by collections_prep with
Juniper Junos Collection.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Add test requirement for coverage (#50)

[junos] Add test requirement for coverage

Reviewed-by: Daniel Mellado <dmellado@redhat.com>
             https://github.com/danielmellado
## Change ospf to ospfv2